### PR TITLE
Any heredocs we use need to be literal

### DIFF
--- a/state/models.go
+++ b/state/models.go
@@ -109,7 +109,7 @@ type Definition struct {
 }
 
 var commandWrapper = `
-bash << _FLOTILLA_EOF
+bash << \_FLOTILLA_EOF
 set -x
 set -e
 {{.Command}}


### PR DESCRIPTION
Without a literal heredoc, some standard bash syntax will break because things get evaluated at the wrong time - function and variable definitions happen in the bash script wrapped by the heredoc, but variable substitutions and subshells happen when the heredoc is evaluated (which is before these user-defined variables and functions exist)