### PR TITLE
Add alias-based routes

### DIFF
--- a/flotilla/endpoints.go
+++ b/flotilla/endpoints.go
@@ -3,14 +3,15 @@ package flotilla
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/gorilla/mux"
-	"github.com/stitchfix/flotilla-os/exceptions"
-	"github.com/stitchfix/flotilla-os/services"
-	"github.com/stitchfix/flotilla-os/state"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/gorilla/mux"
+	"github.com/stitchfix/flotilla-os/exceptions"
+	"github.com/stitchfix/flotilla-os/services"
+	"github.com/stitchfix/flotilla-os/state"
 )
 
 type endpoints struct {
@@ -38,6 +39,9 @@ type launchRequestV2 struct {
 	*launchRequest
 }
 
+//
+// RunTags represents which user is responsible for a task run
+//
 type RunTags struct {
 	OwnerEmail string `json:"owner_email"`
 	TeamName   string `json:"team_name"`
@@ -48,9 +52,8 @@ func (ep *endpoints) getURLParam(v url.Values, key string, defaultValue string) 
 	val, ok := v[key]
 	if ok && len(val) > 0 {
 		return val[0]
-	} else {
-		return defaultValue
 	}
+	return defaultValue
 }
 
 func (ep *endpoints) getFilters(params url.Values, nonFilters map[string]bool) (map[string]string, map[string]string) {
@@ -277,7 +280,7 @@ func (ep *endpoints) CreateRunV2(w http.ResponseWriter, r *http.Request) {
 
 	if len(lr.RunTags.OwnerEmail) == 0 || len(lr.RunTags.TeamName) == 0 {
 		ep.encodeError(w, exceptions.MalformedInput{
-			fmt.Sprintf("run_tags must exist in body and contain [owner_email] and [team_name]")})
+			ErrorString: fmt.Sprintf("run_tags must exist in body and contain [owner_email] and [team_name]")})
 		return
 	}
 
@@ -300,12 +303,35 @@ func (ep *endpoints) CreateRunV4(w http.ResponseWriter, r *http.Request) {
 
 	if len(lr.RunTags.OwnerID) == 0 {
 		ep.encodeError(w, exceptions.MalformedInput{
-			fmt.Sprintf("run_tags must exist in body and contain [owner_id]")})
+			ErrorString: fmt.Sprintf("run_tags must exist in body and contain [owner_id]")})
 		return
 	}
 
 	vars := mux.Vars(r)
 	run, err := ep.executionService.Create(vars["definition_id"], lr.ClusterName, lr.Env, lr.RunTags.OwnerID)
+	if err != nil {
+		ep.encodeError(w, err)
+	} else {
+		ep.encodeResponse(w, run)
+	}
+}
+
+func (ep *endpoints) CreateRunByAlias(w http.ResponseWriter, r *http.Request) {
+	var lr launchRequestV2
+	err := ep.decodeRequest(r, &lr)
+	if err != nil {
+		ep.encodeError(w, err)
+		return
+	}
+
+	if len(lr.RunTags.OwnerID) == 0 {
+		ep.encodeError(w, exceptions.MalformedInput{
+			ErrorString: fmt.Sprintf("run_tags must exist in body and contain [owner_id]")})
+		return
+	}
+
+	vars := mux.Vars(r)
+	run, err := ep.executionService.CreateByAlias(vars["alias"], lr.ClusterName, lr.Env, lr.RunTags.OwnerID)
 	if err != nil {
 		ep.encodeError(w, err)
 	} else {

--- a/flotilla/endpoints.go
+++ b/flotilla/endpoints.go
@@ -157,6 +157,16 @@ func (ep *endpoints) GetDefinition(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (ep *endpoints) GetDefinitionByAlias(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	definition, err := ep.definitionService.GetByAlias(vars["alias"])
+	if err != nil {
+		ep.encodeError(w, err)
+	} else {
+		ep.encodeResponse(w, definition)
+	}
+}
+
 func (ep *endpoints) CreateDefinition(w http.ResponseWriter, r *http.Request) {
 	var definition state.Definition
 	err := ep.decodeRequest(r, &definition)

--- a/flotilla/endpoints_test.go
+++ b/flotilla/endpoints_test.go
@@ -3,13 +3,14 @@ package flotilla
 import (
 	"bytes"
 	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/gorilla/mux"
 	"github.com/stitchfix/flotilla-os/config"
 	"github.com/stitchfix/flotilla-os/services"
 	"github.com/stitchfix/flotilla-os/state"
 	"github.com/stitchfix/flotilla-os/testutils"
-	"net/http/httptest"
-	"testing"
 )
 
 func setUp(t *testing.T) *mux.Router {
@@ -18,9 +19,9 @@ func setUp(t *testing.T) *mux.Router {
 	imp := testutils.ImplementsAllTheThings{
 		T: t,
 		Definitions: map[string]state.Definition{
-			"A": {DefinitionID: "A"},
-			"B": {DefinitionID: "B"},
-			"C": {DefinitionID: "C", Image: "invalidimage"},
+			"A": {DefinitionID: "A", Alias: "aliasA"},
+			"B": {DefinitionID: "B", Alias: "aliasB"},
+			"C": {DefinitionID: "C", Alias: "aliasC", Image: "invalidimage"},
 		},
 		Runs: map[string]state.Run{
 			"runA": {DefinitionID: "A", ClusterName: "A",
@@ -245,6 +246,38 @@ func TestEndpoints_GetDefinition(t *testing.T) {
 	router := setUp(t)
 
 	req := httptest.NewRequest("GET", "/api/v1/task/A", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+	resp := w.Result()
+
+	if resp.Header.Get("Content-Type") != "application/json; charset=utf-8" {
+		t.Errorf("Expected Content-Type [application/json; charset=utf-8], but was [%s]", resp.Header.Get("Content-Type"))
+	}
+
+	if resp.StatusCode != 200 {
+		t.Errorf("Expected status 200, was %v", resp.StatusCode)
+	}
+
+	var r state.Definition
+	err := json.NewDecoder(resp.Body).Decode(&r)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if r.DefinitionID != "A" {
+		t.Errorf("Expected definition_id [A] but was [%s]", r.DefinitionID)
+	}
+
+	if r.Env == nil {
+		t.Errorf("Expected non-nil environment")
+	}
+}
+
+func TestEndpoints_GetDefinitionByAlias(t *testing.T) {
+	router := setUp(t)
+
+	req := httptest.NewRequest("GET", "/api/v1/task/alias/aliasA", nil)
 	w := httptest.NewRecorder()
 
 	router.ServeHTTP(w, req)

--- a/flotilla/endpoints_test.go
+++ b/flotilla/endpoints_test.go
@@ -215,6 +215,44 @@ func TestEndpoints_CreateRun4(t *testing.T) {
 	}
 }
 
+func TestEndpoints_CreateRunByAlias(t *testing.T) {
+	router := setUp(t)
+
+	newRun := `{"cluster":"cupcake", "env":[{"name":"E1","value":"V1"}], "run_tags":{"owner_id":"flotilla"}}`
+	req := httptest.NewRequest("PUT", "/api/v1/task/alias/aliasA/execute", bytes.NewBufferString(newRun))
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	resp := w.Result()
+
+	if resp.Header.Get("Content-Type") != "application/json; charset=utf-8" {
+		t.Errorf("Expected Content-Type [application/json; charset=utf-8], but was [%s]", resp.Header.Get("Content-Type"))
+	}
+
+	if resp.StatusCode != 200 {
+		t.Errorf("Expected status 200, was %v", resp.StatusCode)
+	}
+
+	r := state.Run{}
+	err := json.NewDecoder(resp.Body).Decode(&r)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if len(r.RunID) == 0 {
+		t.Errorf("Expected non-empty run id")
+	}
+
+	if r.Status != state.StatusQueued {
+		t.Errorf("Expected new run to have status [%s] but was [%s]", state.StatusQueued, r.Status)
+	}
+
+	if r.User != "flotilla" {
+		t.Errorf("Expected new run to have user set to run_tags.owner_id but was [%s]", r.User)
+	}
+}
+
 func TestEndpoints_DeleteDefinition(t *testing.T) {
 	router := setUp(t)
 

--- a/flotilla/router.go
+++ b/flotilla/router.go
@@ -13,6 +13,7 @@ func NewRouter(ep endpoints) *mux.Router {
 	v1.HandleFunc("/task/{definition_id}", ep.DeleteDefinition).Methods("DELETE")
 	v1.HandleFunc("/task/{definition_id}/execute", ep.CreateRun).Methods("PUT")
 	v1.HandleFunc("/task/alias/{alias}", ep.GetDefinitionByAlias).Methods("GET")
+	v1.HandleFunc("/task/alias/{alias}/execute", ep.CreateRunByAlias).Methods("PUT")
 
 	v1.HandleFunc("/history", ep.ListRuns).Methods("GET")
 	v1.HandleFunc("/history/{run_id}", ep.GetRun).Methods("GET")

--- a/flotilla/router.go
+++ b/flotilla/router.go
@@ -12,6 +12,7 @@ func NewRouter(ep endpoints) *mux.Router {
 	v1.HandleFunc("/task/{definition_id}", ep.UpdateDefinition).Methods("PUT")
 	v1.HandleFunc("/task/{definition_id}", ep.DeleteDefinition).Methods("DELETE")
 	v1.HandleFunc("/task/{definition_id}/execute", ep.CreateRun).Methods("PUT")
+	v1.HandleFunc("/task/alias/{alias}", ep.GetDefinitionByAlias).Methods("GET")
 
 	v1.HandleFunc("/history", ep.ListRuns).Methods("GET")
 	v1.HandleFunc("/history/{run_id}", ep.GetRun).Methods("GET")

--- a/services/definition.go
+++ b/services/definition.go
@@ -17,6 +17,7 @@ import (
 type DefinitionService interface {
 	Create(definition *state.Definition) (state.Definition, error)
 	Get(definitionID string) (state.Definition, error)
+	GetByAlias(alias string) (state.Definition, error)
 	List(limit int, offset int, sortBy string,
 		order string, filters map[string]string,
 		envFilters map[string]string) (state.DefinitionList, error)
@@ -97,6 +98,10 @@ func (ds *definitionService) aliasExists(alias string) (bool, error) {
 //
 func (ds *definitionService) Get(definitionID string) (state.Definition, error) {
 	return ds.sm.GetDefinition(definitionID)
+}
+
+func (ds *definitionService) GetByAlias(alias string) (state.Definition, error) {
+	return ds.sm.GetDefinitionByAlias(alias)
 }
 
 // List lists definitions

--- a/state/manager.go
+++ b/state/manager.go
@@ -18,6 +18,7 @@ type Manager interface {
 		order string, filters map[string]string,
 		envFilters map[string]string) (DefinitionList, error)
 	GetDefinition(definitionID string) (Definition, error)
+	GetDefinitionByAlias(alias string) (Definition, error)
 	UpdateDefinition(definitionID string, updates Definition) (Definition, error)
 	CreateDefinition(d Definition) error
 	DeleteDefinition(definitionID string) error

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -144,6 +144,11 @@ const ListDefinitionsSQL = DefinitionSelect + "\n%s %s limit $1 offset $2"
 const GetDefinitionSQL = DefinitionSelect + "\nwhere definition_id = $1"
 
 //
+// GetDefinitionByAliasSQL get definition by alias
+//
+const GetDefinitionByAliasSQL = DefinitionSelect + "\nwhere alias = $1"
+
+//
 // RunSelect postgres specific query for runs
 //
 const RunSelect = `

--- a/state/pg_state_manager.go
+++ b/state/pg_state_manager.go
@@ -143,6 +143,20 @@ func (sm *SQLStateManager) GetDefinition(definitionID string) (Definition, error
 }
 
 //
+// GetDefinitionByAlias returns a single definition by id
+//
+func (sm *SQLStateManager) GetDefinitionByAlias(alias string) (Definition, error) {
+	var err error
+	var definition Definition
+	err = sm.db.Get(&definition, GetDefinitionByAliasSQL, alias)
+	if err != nil && err == sql.ErrNoRows {
+		return definition, exceptions.MissingResource{
+			fmt.Sprintf("Definition with alias %s not found", alias)}
+	}
+	return definition, err
+}
+
+//
 // UpdateDefinition updates a definition
 // - updates can be partial
 //

--- a/state/pg_state_manager_test.go
+++ b/state/pg_state_manager_test.go
@@ -213,6 +213,33 @@ func TestSQLStateManager_GetDefinition(t *testing.T) {
 	}
 }
 
+func TestSQLStateManager_GetDefinitionByAlias(t *testing.T) {
+	defer tearDown()
+	sm := setUp()
+
+	dE, _ := sm.GetDefinitionByAlias("aliasE")
+	if dE.DefinitionID != "E" {
+		t.Errorf("Expected definition E to be fetched, got %s", dE.DefinitionID)
+	}
+
+	if dE.Env != nil {
+		t.Errorf("Expected empty environment but got %s", *dE.Env)
+	}
+
+	if len(*dE.Ports) != 2 {
+		t.Errorf("Expected 2 ports but got %v", *dE.Ports)
+	}
+
+	if dE.Tags != nil {
+		t.Errorf("Expected empty tags but got %s", *dE.Tags)
+	}
+
+	_, err := sm.GetDefinitionByAlias("aliasZ")
+	if err == nil {
+		t.Errorf("Expected get for non-existent definition Z to return error, was nil")
+	}
+}
+
 func TestSQLStateManager_CreateDefinition(t *testing.T) {
 	defer tearDown()
 	sm := setUp()

--- a/state/pg_state_manager_test.go
+++ b/state/pg_state_manager_test.go
@@ -1,13 +1,14 @@
 package state
 
 import (
-	"github.com/jmoiron/sqlx"
-	_ "github.com/lib/pq"
-	"github.com/stitchfix/flotilla-os/config"
 	"log"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/lib/pq"
+	"github.com/stitchfix/flotilla-os/config"
 )
 
 func getDB(conf config.Config) *sqlx.DB {
@@ -143,15 +144,15 @@ func TestSQLStateManager_ListDefinitions(t *testing.T) {
 	}
 
 	if len(*dA.Env) != 1 {
-		t.Errorf("Expected returned definitions to have correctly attached env vars, was %s", dA.Env)
+		t.Errorf("Expected returned definitions to have correctly attached env vars, was %v", dA.Env)
 	}
 
 	if len(*dA.Ports) != 1 {
-		t.Errorf("Expected returned definitions to have correctly attached ports, was %s", dA.Ports)
+		t.Errorf("Expected returned definitions to have correctly attached ports, was %v", dA.Ports)
 	}
 
 	if len(*dA.Tags) != 2 {
-		t.Errorf("Expected returned definitions to have correctly attached tags, was %s", dA.Tags)
+		t.Errorf("Expected returned definitions to have correctly attached tags, was %v", dA.Tags)
 	}
 
 	// Test ordering and offset
@@ -199,7 +200,7 @@ func TestSQLStateManager_GetDefinition(t *testing.T) {
 	}
 
 	if len(*dE.Ports) != 2 {
-		t.Errorf("Expected 2 ports but got %s", *dE.Ports)
+		t.Errorf("Expected 2 ports but got %v", *dE.Ports)
 	}
 
 	if dE.Tags != nil {
@@ -356,7 +357,7 @@ func TestSQLStateManager_ListRuns(t *testing.T) {
 	}
 
 	if len(*r0.Env) != 1 {
-		t.Errorf("Expected returned runs to have correctly attached env vars, was %s", r0.Env)
+		t.Errorf("Expected returned runs to have correctly attached env vars, was %v", r0.Env)
 	}
 
 	// Test ordering and offset
@@ -405,7 +406,7 @@ func TestSQLStateManager_GetRun(t *testing.T) {
 	}
 
 	if len(*r2.Env) != 1 {
-		t.Errorf("Expected environment to have exactly one entry, but was %s", len(*r2.Env))
+		t.Errorf("Expected environment to have exactly one entry, but was %v", len(*r2.Env))
 	}
 
 	_, err := sm.GetRun("run100")

--- a/testutils/mocks.go
+++ b/testutils/mocks.go
@@ -2,10 +2,11 @@ package testutils
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/stitchfix/flotilla-os/config"
 	"github.com/stitchfix/flotilla-os/queue"
 	"github.com/stitchfix/flotilla-os/state"
-	"testing"
 )
 
 //
@@ -66,6 +67,17 @@ func (iatt *ImplementsAllTheThings) GetDefinition(definitionID string) (state.De
 		err = fmt.Errorf("No definition %s", definitionID)
 	}
 	return d, err
+}
+
+// GetDefinitionByAlias - StateManager
+func (iatt *ImplementsAllTheThings) GetDefinitionByAlias(alias string) (state.Definition, error) {
+	iatt.Calls = append(iatt.Calls, "GetDefinitionByAlias")
+	for _, d := range iatt.Definitions {
+		if d.Alias == alias {
+			return d, nil
+		}
+	}
+	return state.Definition{}, fmt.Errorf("No definition with alias %s", alias)
 }
 
 // UpdateDefinition - StateManager

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -651,7 +651,7 @@
 			"revisionTime": "2017-07-07T05:36:02Z"
 		},
 		{
-			"checksumSHA1": "Gk3jTNQ5uGDUE0WMJFWcYz9PMps=",
+			"checksumSHA1": "q5SZBWFVC3wOIzftf+l/h5WLG1k=",
 			"path": "github.com/lib/pq/oid",
 			"revision": "dd1fe2071026ce53f36a39112e645b4d4f5793a4",
 			"revisionTime": "2017-07-07T05:36:02Z"
@@ -789,7 +789,7 @@
 			"revisionTime": "2017-07-18T17:12:47Z"
 		},
 		{
-			"checksumSHA1": "YLO+lvF3Vn7sYbgJZtnrnctrpaA=",
+			"checksumSHA1": "clYzF13hcnUKF7X/o5TgvjrCLdM=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "7a4fde3fda8ef580a89dbae8138c26041be14299",
 			"revisionTime": "2017-06-29T20:26:00Z"
@@ -807,7 +807,7 @@
 			"revisionTime": "2017-07-09T00:38:22Z"
 		},
 		{
-			"checksumSHA1": "Anof4bt0AU+Sa3R8Rq0KBnlpbaQ=",
+			"checksumSHA1": "kKylzIrLEnH8NKyeVAL0dq5gjVQ=",
 			"path": "golang.org/x/text/unicode/norm",
 			"revision": "836efe42bb4aa16aaa17b9c155d8813d336ed720",
 			"revisionTime": "2017-07-09T00:38:22Z"


### PR DESCRIPTION
Flotilla has long had the ability to do approximate matching to search by alias, but a common use case has been identifying tasks by alias when looking them up or running them. The clients that do this have had built-in logic to search, filter for exact match, then perform operations based on the definition id

This commit adds support for direct lookups and task executions by exact match on the task alias

There are also some gofmt-related tweaks, isolated to the files touched by this commit.