### PR TITLE
NULLS LAST if you're sorting.

### DIFF
--- a/state/pg_state_manager.go
+++ b/state/pg_state_manager.go
@@ -81,7 +81,7 @@ func (sm *SQLStateManager) makeEnvWhereClause(filters map[string]string) []strin
 func (sm *SQLStateManager) orderBy(obj orderable, field string, order string) (string, error) {
 	if order == "asc" || order == "desc" {
 		if obj.validOrderField(field) {
-			return fmt.Sprintf("order by %s %s", field, order), nil
+			return fmt.Sprintf("order by %s %s NULLS LAST", field, order), nil
 		}
 		return "", fmt.Errorf("Invalid field to order by [%s], must be one of [%s]",
 			field,


### PR DESCRIPTION
If you're sorting, you don't want nulls.  thoughts?

This is to avoid the current situation - when you sort by `started_at DESC` (which is what I want to see 90% of the time) you see all the jobs that never started.

Fixes #29 