### PR TITLE
set permissions on target queue

### DIFF
--- a/execution/engine/ecs_engine_test.go
+++ b/execution/engine/ecs_engine_test.go
@@ -60,6 +60,10 @@ func (msqs *mockSQSClient) GetQueueAttributes(input *sqs.GetQueueAttributesInput
 	}, nil
 }
 
+func (msqs *mockSQSClient) SetQueueAttributes(input *sqs.SetQueueAttributesInput) (*sqs.SetQueueAttributesOutput, error) {
+	return &sqs.SetQueueAttributesOutput{}, nil
+}
+
 type mockCloudWatchClient struct {
 }
 


### PR DESCRIPTION
We were automatically creating the rule that routes ecs status update events to a target queue but were not updating the permissions on the target queue to allow the rule to send messages to it