### PR TITLE
Reduce the amount of bash wrapping

### DIFF
--- a/state/models.go
+++ b/state/models.go
@@ -109,14 +109,10 @@ type Definition struct {
 }
 
 var commandWrapper = `
-bash << \_FLOTILLA_EOF
-set -x
 set -e
-{{.Command}}
-_FLOTILLA_EOF
+set -x
 
-exit_code=$?
-exit ${exit_code}
+{{.Command}}
 `
 var commandTemplate, _ = template.New("command").Parse(commandWrapper)
 


### PR DESCRIPTION
The motivation for this is that we realized the SIGTERM sent by ECS gets lost in layers of bash wrapping. By cutting down the amount of bash wrapping, it becomes easier to handle linux signals in scripts directly. The functionality should be identical. 