### PR TITLE
Adds the concept of an optional task role ARN for the ecs engine.

### DIFF
--- a/conf/config.yml
+++ b/conf/config.yml
@@ -68,3 +68,36 @@ http:
 # with ownership information set - "who -owns- this run?"
 #
 owner_id_var: FLOTILLA_RUN_OWNER_ID
+
+#
+# Execution engine specific variables
+#
+#
+# ECS Engine
+#
+# ecs.engine.task_role_arn
+#
+# To use a specific task role ARN (which means all
+# tasks will use this role to make requests to AWS, if any)
+#
+# 1. The AWS user that is running flotilla must have the
+#    iam:PassRole permission for the role you specify
+# 2. Add the following entity to the "trust relationships"
+#    of your task role
+#   {
+#      "Sid": "",
+#      "Effect": "Allow",
+#      "Principal": {
+#        "Service": "ecs-tasks.amazonaws.com"
+#      },
+#      "Action": "sts:AssumeRole"
+#    }
+#  which will allow ecs tasks to assume the role you provide
+#  in the `ecs.engine.task_role_arn` config var.
+#
+#
+#
+#ecs:
+#  engine:
+#    task_role_arn: arn:aws:iam::123456789:role/example
+

--- a/execution/adapter/ecs_adapter_test.go
+++ b/execution/adapter/ecs_adapter_test.go
@@ -155,6 +155,43 @@ func TestEcsAdapter_AdaptRun(t *testing.T) {
 	}
 }
 
+func TestEcsAdapter_AdaptRun2(t *testing.T) {
+	taskRoleArn := "cupcake"
+	adapter := setUp(t)
+	adapter.taskRoleArn = &taskRoleArn
+
+	definition := state.Definition{
+		Arn:           "darn",
+		GroupName:     "groupa",
+		ContainerName: "mynameiswhat",
+	}
+
+	cmd := "_overridden_cmd"
+	mem := int64(11)
+	cpu := int64(111)
+	k1 := "ENVVAR_A"
+	k2 := "ENVVAR_B"
+	v1 := "VALUEA"
+	v2 := "VALUEB"
+	env := state.EnvList([]state.EnvVar{
+		{Name: k1, Value: v1},
+		{Name: k2, Value: v2},
+	})
+
+	run := state.Run{
+		ClusterName: "clusta",
+		GroupName:   "groupa",
+		Env:         &env,
+		Command:     &cmd,
+		Memory:      &mem,
+		Cpu:         &cpu,
+	}
+	rti := adapter.AdaptRun(definition, run)
+	if rti.Overrides.TaskRoleArn == nil || *rti.Overrides.TaskRoleArn != taskRoleArn {
+		t.Errorf("Expected non-nil taskRoleArn with value: %s", taskRoleArn)
+	}
+}
+
 func TestEcsAdapter_AdaptTask(t *testing.T) {
 	adapter := setUp(t)
 


### PR DESCRIPTION
See example config.yml for details.

If `ecs.engine.task_role_arn` is set all tasks will use this ARN.
Otherwise, like the existing behavior, all tasks will use the role
of the ECS cluster they're running on.