### PR TITLE
Adding placement strategy and constraints

### DIFF
--- a/execution/adapter/ecs_adapter.go
+++ b/execution/adapter/ecs_adapter.go
@@ -237,10 +237,10 @@ func (a *ecsAdapter) cpuPlacementStrategy() *ecs.PlacementStrategy {
 
 func (a *ecsAdapter) gpuPlacementConstraints(definition state.Definition, run state.Run) *ecs.PlacementConstraint {
 	if definition.Gpu != nil {
-		// https://aws.amazon.com/ec2/instance-types/#Accelerated_Computing
 		return &ecs.PlacementConstraint{
 			Type:       aws.String("memberOf"),
-			Expression: aws.String("attribute:ecs.instance-type =~ p.*"),
+			// https://aws.amazon.com/ec2/instance-types/#Accelerated_Computing
+			Expression: aws.String("attribute:ecs.instance-type =~ (p[2,3]|g[3,4]|f[1]).*"),
 		}
 	}
 	return nil

--- a/execution/adapter/ecs_adapter.go
+++ b/execution/adapter/ecs_adapter.go
@@ -238,10 +238,9 @@ func (a *ecsAdapter) cpuPlacementStrategy() *ecs.PlacementStrategy {
 func (a *ecsAdapter) gpuPlacementConstraints(definition state.Definition, run state.Run) *ecs.PlacementConstraint {
 	if definition.Gpu != nil {
 		// https://aws.amazon.com/ec2/instance-types/#Accelerated_Computing
-		expression := "attribute:ecs.instance-type =~ p.*"
 		return &ecs.PlacementConstraint{
 			Type:       aws.String("memberOf"),
-			Expression: &expression,
+			Expression: aws.String("attribute:ecs.instance-type =~ p.*"),
 		}
 	}
 	return nil


### PR DESCRIPTION
- Adding support for GPU centric jobs to be scheduled on GPU node types only
- Using `binpack` for placement of jobs by Memory and CPU (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html)