### PR TITLE
Make privileged mode optional during task definition

### DIFF
--- a/execution/adapter/ecs_adapter.go
+++ b/execution/adapter/ecs_adapter.go
@@ -373,10 +373,10 @@ func (a *ecsAdapter) AdaptDefinition(definition state.Definition) ecs.RegisterTa
 		containerDef.DockerLabels["tags"] = &tagsList
 	}
 	networkMode := "bridge"
-	if *(definition.Privileged) == true {
-		privilegedOverride := true
+
+	if definition.Privileged != nil && *(definition.Privileged) == true {
 		networkMode = "host"
-		containerDef.Privileged = &privilegedOverride
+		containerDef.Privileged = definition.Privileged
 	}
 
 	return ecs.RegisterTaskDefinitionInput{

--- a/execution/adapter/ecs_adapter.go
+++ b/execution/adapter/ecs_adapter.go
@@ -372,8 +372,13 @@ func (a *ecsAdapter) AdaptDefinition(definition state.Definition) ecs.RegisterTa
 		tagsList := strings.Join(*definition.Tags, ",")
 		containerDef.DockerLabels["tags"] = &tagsList
 	}
+	networkMode := "bridge"
+	if *(definition.Privileged) == true {
+		privilegedOverride := true
+		networkMode = "host"
+		containerDef.Privileged = &privilegedOverride
+	}
 
-	networkMode := "host"
 	return ecs.RegisterTaskDefinitionInput{
 		ContainerDefinitions: []*ecs.ContainerDefinition{containerDef},
 		Family:               &definition.DefinitionID,
@@ -444,7 +449,7 @@ func (a *ecsAdapter) defaultContainerDefinition() *ecs.ContainerDefinition {
 	essential := true
 	user := "root"
 	disableNetworking := false
-	privileged := true
+	privileged := false
 
 	logDriver := a.conf.GetString("log.driver.name")
 	if len(logDriver) == 0 {

--- a/state/models.go
+++ b/state/models.go
@@ -119,6 +119,7 @@ type Definition struct {
 	Env           *EnvList   `json:"env"`
 	Ports         *PortsList `json:"ports,omitempty"`
 	Tags          *Tags      `json:"tags,omitempty"`
+	Privileged    *bool      `json:"privileged,omitempty"`
 }
 
 var commandWrapper = `

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -135,7 +135,9 @@ select
   env::TEXT                 as env,
   ports                     as ports,
   tags                      as tags,
-  td.privileged             as privileged
+  td.privileged             as privileged,
+  td.cpu                    as cpu,
+  td.gpu                    as gpu
   from (select * from task_def) td left outer join
     (select task_def_id,
       array_to_json(array_agg(port))::TEXT as ports

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -16,7 +16,6 @@ CREATE TABLE IF NOT EXISTS task_def (
   group_name character varying NOT NULL,
   memory integer,
   cpu integer,
-  gpu integer,
   command text,
   env jsonb,
   -- Refactor these
@@ -138,8 +137,7 @@ select
   ports                     as ports,
   tags                      as tags,
   td.privileged             as privileged,
-  td.cpu                    as cpu,
-  td.gpu                    as gpu
+  td.cpu                    as cpu
   from (select * from task_def) td left outer join
     (select task_def_id,
       array_to_json(array_agg(port))::TEXT as ports

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -134,7 +134,8 @@ select
   coalesce(td.task_type,'') as tasktype,
   env::TEXT                 as env,
   ports                     as ports,
-  tags                      as tags
+  tags                      as tags,
+  td.privileged             as privileged,
   from (select * from task_def) td left outer join
     (select task_def_id,
       array_to_json(array_agg(port))::TEXT as ports

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -15,6 +15,8 @@ CREATE TABLE IF NOT EXISTS task_def (
   image character varying NOT NULL,
   group_name character varying NOT NULL,
   memory integer,
+  cpu integer,
+  gpu integer,
   command text,
   env jsonb,
   -- Refactor these

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -22,6 +22,7 @@ CREATE TABLE IF NOT EXISTS task_def (
   arn character varying,
   container_name character varying NOT NULL,
   task_type character varying,
+  privileged boolean,
   -- Refactor these
   CONSTRAINT task_def_alias UNIQUE(alias)
 );

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -135,7 +135,7 @@ select
   env::TEXT                 as env,
   ports                     as ports,
   tags                      as tags,
-  td.privileged             as privileged,
+  td.privileged             as privileged
   from (select * from task_def) td left outer join
     (select task_def_id,
       array_to_json(array_agg(port))::TEXT as ports

--- a/state/pg_state_manager.go
+++ b/state/pg_state_manager.go
@@ -247,7 +247,7 @@ func (sm *SQLStateManager) UpdateDefinition(definitionID string, updates Definit
       arn = $2, image = $3,
       container_name = $4, "user" = $5,
       alias = $6, memory = $7,
-      command = $8, env = $9, privileged = $10
+      command = $8, env = $9, privileged = $10, cpu = $11, gpu = $12
     WHERE definition_id = $1;
     `
 
@@ -288,7 +288,7 @@ func (sm *SQLStateManager) UpdateDefinition(definitionID string, updates Definit
 		update, definitionID,
 		existing.Arn, existing.Image, existing.ContainerName,
 		existing.User, existing.Alias, existing.Memory,
-		existing.Command, existing.Env, existing.Privileged); err != nil {
+		existing.Command, existing.Env, existing.Privileged, existing.Cpu, existing.Gpu); err != nil {
 		return existing, errors.Wrapf(err, "issue updating definition [%s]", definitionID)
 	}
 
@@ -329,9 +329,9 @@ func (sm *SQLStateManager) CreateDefinition(d Definition) error {
 	insert := `
     INSERT INTO task_def(
       arn, definition_id, image, group_name,
-      container_name, "user", alias, memory, command, env, privileged
+      container_name, "user", alias, memory, command, env, privileged, cpu, gpu
     )
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13);
     `
 
 	insertPorts := `
@@ -357,7 +357,7 @@ func (sm *SQLStateManager) CreateDefinition(d Definition) error {
 
 	if _, err = tx.Exec(insert,
 		d.Arn, d.DefinitionID, d.Image, d.GroupName, d.ContainerName,
-		d.User, d.Alias, d.Memory, d.Command, d.Env, d.Privileged); err != nil {
+		d.User, d.Alias, d.Memory, d.Command, d.Env, d.Privileged, d.Cpu, d.Gpu); err != nil {
 		tx.Rollback()
 		return errors.Wrapf(
 			err, "issue creating new task definition with alias [%s] and id [%s]", d.DefinitionID, d.Alias)

--- a/state/pg_state_manager.go
+++ b/state/pg_state_manager.go
@@ -247,7 +247,7 @@ func (sm *SQLStateManager) UpdateDefinition(definitionID string, updates Definit
       arn = $2, image = $3,
       container_name = $4, "user" = $5,
       alias = $6, memory = $7,
-      command = $8, env = $9, privileged = $10, cpu = $11, gpu = $12
+      command = $8, env = $9, privileged = $10, cpu = $11
     WHERE definition_id = $1;
     `
 
@@ -288,7 +288,7 @@ func (sm *SQLStateManager) UpdateDefinition(definitionID string, updates Definit
 		update, definitionID,
 		existing.Arn, existing.Image, existing.ContainerName,
 		existing.User, existing.Alias, existing.Memory,
-		existing.Command, existing.Env, existing.Privileged, existing.Cpu, existing.Gpu); err != nil {
+		existing.Command, existing.Env, existing.Privileged, existing.Cpu); err != nil {
 		return existing, errors.Wrapf(err, "issue updating definition [%s]", definitionID)
 	}
 
@@ -329,9 +329,9 @@ func (sm *SQLStateManager) CreateDefinition(d Definition) error {
 	insert := `
     INSERT INTO task_def(
       arn, definition_id, image, group_name,
-      container_name, "user", alias, memory, command, env, privileged, cpu, gpu
+      container_name, "user", alias, memory, command, env, privileged, cpu
     )
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13);
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12);
     `
 
 	insertPorts := `
@@ -357,7 +357,7 @@ func (sm *SQLStateManager) CreateDefinition(d Definition) error {
 
 	if _, err = tx.Exec(insert,
 		d.Arn, d.DefinitionID, d.Image, d.GroupName, d.ContainerName,
-		d.User, d.Alias, d.Memory, d.Command, d.Env, d.Privileged, d.Cpu, d.Gpu); err != nil {
+		d.User, d.Alias, d.Memory, d.Command, d.Env, d.Privileged, d.Cpu); err != nil {
 		tx.Rollback()
 		return errors.Wrapf(
 			err, "issue creating new task definition with alias [%s] and id [%s]", d.DefinitionID, d.Alias)

--- a/state/pg_state_manager.go
+++ b/state/pg_state_manager.go
@@ -288,7 +288,7 @@ func (sm *SQLStateManager) UpdateDefinition(definitionID string, updates Definit
 		update, definitionID,
 		existing.Arn, existing.Image, existing.ContainerName,
 		existing.User, existing.Alias, existing.Memory,
-		existing.Command, existing.Env, *(existing.Privileged)); err != nil {
+		existing.Command, existing.Env, existing.Privileged); err != nil {
 		return existing, errors.Wrapf(err, "issue updating definition [%s]", definitionID)
 	}
 
@@ -357,7 +357,7 @@ func (sm *SQLStateManager) CreateDefinition(d Definition) error {
 
 	if _, err = tx.Exec(insert,
 		d.Arn, d.DefinitionID, d.Image, d.GroupName, d.ContainerName,
-		d.User, d.Alias, d.Memory, d.Command, d.Env, *(d.Privileged)); err != nil {
+		d.User, d.Alias, d.Memory, d.Command, d.Env, d.Privileged); err != nil {
 		tx.Rollback()
 		return errors.Wrapf(
 			err, "issue creating new task definition with alias [%s] and id [%s]", d.DefinitionID, d.Alias)

--- a/state/pg_state_manager.go
+++ b/state/pg_state_manager.go
@@ -288,7 +288,7 @@ func (sm *SQLStateManager) UpdateDefinition(definitionID string, updates Definit
 		update, definitionID,
 		existing.Arn, existing.Image, existing.ContainerName,
 		existing.User, existing.Alias, existing.Memory,
-		existing.Command, existing.Env, existing.Privileged); err != nil {
+		existing.Command, existing.Env, *(existing.Privileged)); err != nil {
 		return existing, errors.Wrapf(err, "issue updating definition [%s]", definitionID)
 	}
 
@@ -357,7 +357,7 @@ func (sm *SQLStateManager) CreateDefinition(d Definition) error {
 
 	if _, err = tx.Exec(insert,
 		d.Arn, d.DefinitionID, d.Image, d.GroupName, d.ContainerName,
-		d.User, d.Alias, d.Memory, d.Command, d.Env, d.Privileged); err != nil {
+		d.User, d.Alias, d.Memory, d.Command, d.Env, *(d.Privileged)); err != nil {
 		tx.Rollback()
 		return errors.Wrapf(
 			err, "issue creating new task definition with alias [%s] and id [%s]", d.DefinitionID, d.Alias)

--- a/state/pg_state_manager.go
+++ b/state/pg_state_manager.go
@@ -247,7 +247,7 @@ func (sm *SQLStateManager) UpdateDefinition(definitionID string, updates Definit
       arn = $2, image = $3,
       container_name = $4, "user" = $5,
       alias = $6, memory = $7,
-      command = $8, env = $9
+      command = $8, env = $9, privileged = $10
     WHERE definition_id = $1;
     `
 
@@ -288,7 +288,7 @@ func (sm *SQLStateManager) UpdateDefinition(definitionID string, updates Definit
 		update, definitionID,
 		existing.Arn, existing.Image, existing.ContainerName,
 		existing.User, existing.Alias, existing.Memory,
-		existing.Command, existing.Env); err != nil {
+		existing.Command, existing.Env, existing.Privileged); err != nil {
 		return existing, errors.Wrapf(err, "issue updating definition [%s]", definitionID)
 	}
 
@@ -329,9 +329,9 @@ func (sm *SQLStateManager) CreateDefinition(d Definition) error {
 	insert := `
     INSERT INTO task_def(
       arn, definition_id, image, group_name,
-      container_name, "user", alias, memory, command, env
+      container_name, "user", alias, memory, command, env, privileged
     )
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);
     `
 
 	insertPorts := `
@@ -357,7 +357,7 @@ func (sm *SQLStateManager) CreateDefinition(d Definition) error {
 
 	if _, err = tx.Exec(insert,
 		d.Arn, d.DefinitionID, d.Image, d.GroupName, d.ContainerName,
-		d.User, d.Alias, d.Memory, d.Command, d.Env); err != nil {
+		d.User, d.Alias, d.Memory, d.Command, d.Env, d.Privileged); err != nil {
 		tx.Rollback()
 		return errors.Wrapf(
 			err, "issue creating new task definition with alias [%s] and id [%s]", d.DefinitionID, d.Alias)

--- a/state/pg_state_manager_test.go
+++ b/state/pg_state_manager_test.go
@@ -163,8 +163,8 @@ func TestSQLStateManager_ListDefinitions(t *testing.T) {
 	}
 
 	dB := dl.Definitions[1]
-	if *(dB.Privileged) != true {
-		t.Errorf("Listing returned incorrect definition, expected true but got %s", *(dA.Privileged))
+	if *(dB.Privileged) != false {
+		t.Errorf("Listing returned incorrect definition, expected false but got %s", *(dB.Privileged))
 	}
 
 	// Test ordering and offset

--- a/state/pg_state_manager_test.go
+++ b/state/pg_state_manager_test.go
@@ -146,8 +146,8 @@ func TestSQLStateManager_ListDefinitions(t *testing.T) {
 		t.Errorf("Listing returned incorrect definition, expected A but got %s", dA.DefinitionID)
 	}
 
-	if *(dA.Privileged) != true {
-		t.Errorf("Listing returned incorrect definition, expected true but got %t", *(dA.Privileged))
+	if *dA.Privileged != true {
+		t.Errorf("Listing returned incorrect definition, expected true but got %v", dA.Privileged)
 	}
 
 	if len(*dA.Env) != 1 {
@@ -163,8 +163,8 @@ func TestSQLStateManager_ListDefinitions(t *testing.T) {
 	}
 
 	dB := dl.Definitions[1]
-	if *(dB.Privileged) != false {
-		t.Errorf("Listing returned incorrect definition, expected false but got %t", *(dB.Privileged))
+	if *dB.Privileged != false {
+		t.Errorf("Listing returned incorrect definition, expected false but got %v", dB.Privileged)
 	}
 
 	// Test ordering and offset

--- a/state/pg_state_manager_test.go
+++ b/state/pg_state_manager_test.go
@@ -147,7 +147,7 @@ func TestSQLStateManager_ListDefinitions(t *testing.T) {
 	}
 
 	if *(dA.Privileged) != true {
-		t.Errorf("Listing returned incorrect definition, expected true but got %s", *(dA.Privileged))
+		t.Errorf("Listing returned incorrect definition, expected true but got %t", *(dA.Privileged))
 	}
 
 	if len(*dA.Env) != 1 {
@@ -164,7 +164,7 @@ func TestSQLStateManager_ListDefinitions(t *testing.T) {
 
 	dB := dl.Definitions[1]
 	if *(dB.Privileged) != false {
-		t.Errorf("Listing returned incorrect definition, expected false but got %s", *(dB.Privileged))
+		t.Errorf("Listing returned incorrect definition, expected false but got %t", *(dB.Privileged))
 	}
 
 	// Test ordering and offset

--- a/state/pg_state_manager_test.go
+++ b/state/pg_state_manager_test.go
@@ -162,11 +162,6 @@ func TestSQLStateManager_ListDefinitions(t *testing.T) {
 		t.Errorf("Expected returned definitions to have correctly attached tags, was %v", dA.Tags)
 	}
 
-	dB := dl.Definitions[1]
-	if *dB.Privileged != false {
-		t.Errorf("Listing returned incorrect definition, expected false but got %v", dB.Privileged)
-	}
-
 	// Test ordering and offset
 	dl, _ = sm.ListDefinitions(1, 1, "group_name", "asc", nil, nil)
 	if dl.Definitions[0].GroupName != "groupW" {


### PR DESCRIPTION
Adding `privileged` flag to the task definition, defaults to false.