### PR TITLE
Increase parallelism on the statusworker

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -651,6 +651,62 @@
 			"revisionTime": "2018-11-22T01:56:15Z"
 		},
 		{
+			"checksumSHA1": "AvBO8FhcdWK1RMF7GiCxzxsgmhQ=",
+			"path": "github.com/go-redis/redis",
+			"revision": "7f69d5e32072d151eb6936cbe2306413e8117488",
+			"revisionTime": "2019-10-08T09:42:12Z",
+			"version": "=v6",
+			"versionExact": "v6"
+		},
+		{
+			"checksumSHA1": "pPBUPs5RJe7jbz3rXtpZe99k3jo=",
+			"path": "github.com/go-redis/redis/internal",
+			"revision": "7f69d5e32072d151eb6936cbe2306413e8117488",
+			"revisionTime": "2019-10-08T09:42:12Z",
+			"version": "=v6",
+			"versionExact": "v6"
+		},
+		{
+			"checksumSHA1": "GQZsUVg/+6UpQAYpc4luMvMutSI=",
+			"path": "github.com/go-redis/redis/internal/consistenthash",
+			"revision": "7f69d5e32072d151eb6936cbe2306413e8117488",
+			"revisionTime": "2019-10-08T09:42:12Z",
+			"version": "=v6",
+			"versionExact": "v6"
+		},
+		{
+			"checksumSHA1": "l66eTZiJqueypc56HXCakGDm784=",
+			"path": "github.com/go-redis/redis/internal/hashtag",
+			"revision": "7f69d5e32072d151eb6936cbe2306413e8117488",
+			"revisionTime": "2019-10-08T09:42:12Z",
+			"version": "=v6",
+			"versionExact": "v6"
+		},
+		{
+			"checksumSHA1": "OHj6H6AyvnbP1rYtWjO4thbD7Ug=",
+			"path": "github.com/go-redis/redis/internal/pool",
+			"revision": "7f69d5e32072d151eb6936cbe2306413e8117488",
+			"revisionTime": "2019-10-08T09:42:12Z",
+			"version": "=v6",
+			"versionExact": "v6"
+		},
+		{
+			"checksumSHA1": "zCo0t+gRBbctwyIpkDLrqRFtXew=",
+			"path": "github.com/go-redis/redis/internal/proto",
+			"revision": "7f69d5e32072d151eb6936cbe2306413e8117488",
+			"revisionTime": "2019-10-08T09:42:12Z",
+			"version": "=v6",
+			"versionExact": "v6"
+		},
+		{
+			"checksumSHA1": "1PH2NoAB/u3IZmLYyCrIbOzqLZ4=",
+			"path": "github.com/go-redis/redis/internal/util",
+			"revision": "7f69d5e32072d151eb6936cbe2306413e8117488",
+			"revisionTime": "2019-10-08T09:42:12Z",
+			"version": "=v6",
+			"versionExact": "v6"
+		},
+		{
 			"checksumSHA1": "bxbDYTjvuovf3t4qYfpUoZ3we4s=",
 			"path": "github.com/gogo/protobuf/proto",
 			"revision": "dadb625850898f31a8e40e83492f4a7132e520a2",

--- a/worker/submit_worker.go
+++ b/worker/submit_worker.go
@@ -2,13 +2,13 @@ package worker
 
 import (
 	"fmt"
-	"time"
-
+	"github.com/go-redis/redis"
 	"github.com/stitchfix/flotilla-os/config"
 	"github.com/stitchfix/flotilla-os/execution/engine"
 	flotillaLog "github.com/stitchfix/flotilla-os/log"
 	"github.com/stitchfix/flotilla-os/state"
 	"gopkg.in/tomb.v2"
+	"time"
 )
 
 type submitWorker struct {
@@ -19,6 +19,7 @@ type submitWorker struct {
 	pollInterval time.Duration
 	t            tomb.Tomb
 	engine       *string
+	redisClient  *redis.Client
 }
 
 func (sw *submitWorker) Initialize(conf config.Config, sm state.Manager, ee engine.Engine, log flotillaLog.Logger, pollInterval time.Duration, engine *string) error {
@@ -28,7 +29,8 @@ func (sw *submitWorker) Initialize(conf config.Config, sm state.Manager, ee engi
 	sw.ee = ee
 	sw.log = log
 	sw.engine = engine
-	sw.log.Log("message", "initialized a submit worker","engine",  *engine)
+	sw.redisClient = redis.NewClient(&redis.Options{Addr: conf.GetString("redis_address"), DB: conf.GetInt("redis_db"),})
+	_ = sw.log.Log("message", "initialized a submit worker", "engine", *engine)
 	return nil
 }
 


### PR DESCRIPTION
To increase the parallelism of the status worker, introducing a timed Redis lock on a runId. Only refereshed once every 5 seconds. This prevents excessive loads on the kubernetes api

using https://redis.io/commands/setnx