### PR TITLE
Adaptive Resource Allocation for EKS pods

### DIFF
--- a/clients/registry/registry.go
+++ b/clients/registry/registry.go
@@ -111,7 +111,7 @@ func (rc *registryClient) IsImageValid(imageRef string) (bool, error) {
 	if err != nil {
 		return false, errors.Wrapf(err, "issue fetching tags for image reference [%s]", imageRef)
 	}
-	
+
 	tag := taggedRef.Tag()
 	for _, t := range tags {
 		if tag == t {

--- a/execution/adapter/ecs_adapter.go
+++ b/execution/adapter/ecs_adapter.go
@@ -201,11 +201,11 @@ func (a *ecsAdapter) AdaptRun(definition state.Definition, run state.Run) ecs.Ru
 	}
 
 	rti := ecs.RunTaskInput{
-		Cluster:              &run.ClusterName,
-		Count:                &n,
-		StartedBy:            aws.String("flotilla"),
-		TaskDefinition:       &definition.Arn,
-		Overrides:            &overrides,
+		Cluster:        &run.ClusterName,
+		Count:          &n,
+		StartedBy:      aws.String("flotilla"),
+		TaskDefinition: &definition.Arn,
+		Overrides:      &overrides,
 	}
 
 	return rti

--- a/execution/adapter/eks_adapter.go
+++ b/execution/adapter/eks_adapter.go
@@ -222,7 +222,7 @@ func (a *eksAdapter) adaptiveResources(definition state.Definition, run state.Ru
 			},
 			"status":        {state.StatusStopped},
 			"command":       {*run.Command},
-			"definition_id": {definition.DefinitionID},
+			"definition_id": {run.DefinitionID},
 		}, nil, []string{state.EKSEngine})
 
 		if err != nil {

--- a/execution/adapter/eks_adapter.go
+++ b/execution/adapter/eks_adapter.go
@@ -86,6 +86,8 @@ func (a *eksAdapter) AdaptFlotillaDefinitionAndRunToJob(definition state.Definit
 	}
 
 	cmdSlice := a.constructCmdSlice(cmd)
+	cmd = strings.Join(cmdSlice, "\n")
+	run.Command = &cmd
 	resourceRequirements := a.constructResourceRequirements(definition, run, manager)
 
 	container := corev1.Container{

--- a/execution/adapter/eks_adapter.go
+++ b/execution/adapter/eks_adapter.go
@@ -220,7 +220,7 @@ func (a *eksAdapter) adaptiveResources(definition state.Definition, run state.Ru
 	mem := state.MinMem
 
 	if definition.AdaptiveResourceAllocation != nil && *definition.AdaptiveResourceAllocation == true {
-		resources, err := manager.GetRunResources(definition.DefinitionID, *run.Command)
+		resources, err := manager.EstimateRunResources(definition.DefinitionID, *run.Command)
 		if err == nil {
 			cpu = resources.Cpu
 			mem = resources.Memory

--- a/execution/adapter/eks_adapter.go
+++ b/execution/adapter/eks_adapter.go
@@ -13,7 +13,7 @@ import (
 
 type EKSAdapter interface {
 	AdaptJobToFlotillaRun(job *batchv1.Job, run state.Run, pod *corev1.Pod) (state.Run, error)
-	AdaptFlotillaDefinitionAndRunToJob(td state.Definition, run state.Run, sa string, schedulerName string) (batchv1.Job, error)
+	AdaptFlotillaDefinitionAndRunToJob(td state.Definition, run state.Run, sa string, schedulerName string, manager state.Manager) (batchv1.Job, error)
 }
 type eksAdapter struct{}
 
@@ -74,8 +74,9 @@ func (a *eksAdapter) AdaptJobToFlotillaRun(job *batchv1.Job, run state.Run, pod 
 	return updated, nil
 }
 
-func (a *eksAdapter) AdaptFlotillaDefinitionAndRunToJob(definition state.Definition, run state.Run, sa string, schedulerName string) (batchv1.Job, error) {
-	resourceRequirements, run := a.constructResourceRequirements(definition, run)
+
+func (a *eksAdapter) AdaptFlotillaDefinitionAndRunToJob(definition state.Definition, run state.Run, sa string, schedulerName string, manager state.Manager) (batchv1.Job, error) {
+	resourceRequirements := a.constructResourceRequirements(definition, run)
 
 	cmd := definition.Command
 	if run.Command != nil {
@@ -232,6 +233,10 @@ func (a *eksAdapter) constructResourceRequirements(definition state.Definition, 
 		Limits: limits,
 	}
 	return resourceRequirements, run
+}
+
+func (a *eksAdapter) adaptiveResources(definition state.Definition, run state.Run) (int64, int64) {
+	return 0, 0
 }
 
 func (a *eksAdapter) constructCmdSlice(cmdString string) []string {

--- a/execution/adapter/eks_adapter.go
+++ b/execution/adapter/eks_adapter.go
@@ -76,12 +76,12 @@ func (a *eksAdapter) AdaptJobToFlotillaRun(job *batchv1.Job, run state.Run, pod 
 
 
 func (a *eksAdapter) AdaptFlotillaDefinitionAndRunToJob(definition state.Definition, run state.Run, sa string, schedulerName string, manager state.Manager) (batchv1.Job, error) {
-	resourceRequirements := a.constructResourceRequirements(definition, run, manager)
-
 	cmd := definition.Command
 	if run.Command != nil {
 		cmd = *run.Command
 	}
+	run.Command = &cmd
+	resourceRequirements := a.constructResourceRequirements(definition, run, manager)
 
 	container := corev1.Container{
 		Name:      run.RunID,

--- a/execution/adapter/eks_adapter.go
+++ b/execution/adapter/eks_adapter.go
@@ -88,7 +88,7 @@ func (a *eksAdapter) AdaptFlotillaDefinitionAndRunToJob(definition state.Definit
 	cmdSlice := a.constructCmdSlice(cmd)
 	cmd = strings.Join(cmdSlice, "\n")
 	run.Command = &cmd
-	resourceRequirements := a.constructResourceRequirements(definition, run, manager)
+	resourceRequirements, run := a.constructResourceRequirements(definition, run, manager)
 
 	container := corev1.Container{
 		Name:      run.RunID,
@@ -192,7 +192,7 @@ func (a *eksAdapter) constructAffinity(definition state.Definition, run state.Ru
 	return affinity
 }
 
-func (a *eksAdapter) constructResourceRequirements(definition state.Definition, run state.Run, manager state.Manager) corev1.ResourceRequirements {
+func (a *eksAdapter) constructResourceRequirements(definition state.Definition, run state.Run, manager state.Manager) (corev1.ResourceRequirements, state.Run) {
 	limits := make(corev1.ResourceList)
 	cpu, mem := a.adaptiveResources(definition, run, manager)
 	cpuQuantity := resource.MustParse(fmt.Sprintf("%dm", cpu))

--- a/execution/adapter/eks_adapter.go
+++ b/execution/adapter/eks_adapter.go
@@ -76,7 +76,7 @@ func (a *eksAdapter) AdaptJobToFlotillaRun(job *batchv1.Job, run state.Run, pod 
 
 
 func (a *eksAdapter) AdaptFlotillaDefinitionAndRunToJob(definition state.Definition, run state.Run, sa string, schedulerName string, manager state.Manager) (batchv1.Job, error) {
-	resourceRequirements := a.constructResourceRequirements(definition, run)
+	resourceRequirements := a.constructResourceRequirements(definition, run, manager)
 
 	cmd := definition.Command
 	if run.Command != nil {
@@ -185,33 +185,9 @@ func (a *eksAdapter) constructAffinity(definition state.Definition, run state.Ru
 	return affinity
 }
 
-func (a *eksAdapter) constructResourceRequirements(definition state.Definition, run state.Run) (corev1.ResourceRequirements, state.Run) {
+func (a *eksAdapter) constructResourceRequirements(definition state.Definition, run state.Run, manager state.Manager) corev1.ResourceRequirements {
 	limits := make(corev1.ResourceList)
-	cpu := *definition.Cpu
-	if run.Cpu != nil {
-		cpu = *run.Cpu
-	}
-	if cpu < state.MinCPU {
-		cpu = state.MinCPU
-	}
-
-	mem := *definition.Memory
-	if run.Memory != nil {
-		mem = *run.Memory
-	}
-	if mem < state.MinMem {
-		mem = state.MinMem
-	}
-
-	// CPU Override for legacy jobs that are high memory, remove once migration is complete.
-	if mem >= 36864 && mem < 131072 && (definition.Gpu == nil || *definition.Gpu == 0) {
-		// using the 8x ratios between cpu and memory ~ r5 class of instances
-		cpuOverride := mem / 8
-		if cpuOverride > cpu {
-			cpu = cpuOverride
-		}
-	}
-
+	cpu, mem := a.adaptiveResources(definition, run, manager)
 	cpuQuantity := resource.MustParse(fmt.Sprintf("%dm", cpu))
 	assignedCpu := cpuQuantity.ScaledValue(resource.Milli)
 	run.Cpu = &assignedCpu
@@ -235,8 +211,69 @@ func (a *eksAdapter) constructResourceRequirements(definition state.Definition, 
 	return resourceRequirements, run
 }
 
-func (a *eksAdapter) adaptiveResources(definition state.Definition, run state.Run) (int64, int64) {
-	return 0, 0
+func (a *eksAdapter) adaptiveResources(definition state.Definition, run state.Run, manager state.Manager) (int64, int64) {
+	cpu := state.MinCPU
+	mem := state.MinMem
+
+	pastRuns, err := manager.ListRuns(1, 0, "started_at", "desc", map[string][]string{
+		"queued_at_since": {
+			time.Now().AddDate(0, 0, -30).Format(time.RFC3339),
+		},
+		"status":        {state.StatusStopped},
+		"command":       {*run.Command},
+		"definition_id": {definition.DefinitionID},
+	}, nil, []string{state.EKSEngine})
+
+	if err != nil {
+		return cpu, mem
+	}
+
+	if len(pastRuns.Runs) > 0 {
+		lastRun := pastRuns.Runs[0]
+		if lastRun.MaxMemoryUsed != nil && lastRun.MaxCpuUsed != nil {
+			if *lastRun.ExitCode == 0 {
+				cpu = int64(float64(*lastRun.MaxCpuUsed) * 1.1)
+				mem = int64(float64(*lastRun.MaxMemoryUsed) * 1.25)
+			} else {
+				if !strings.Contains(*lastRun.ExitReason, "OOM") {
+					cpu = int64(float64(*lastRun.MaxCpuUsed) * 1.1)
+					mem = int64(float64(*lastRun.MaxMemoryUsed) * 1.50)
+				} else {
+					cpu = int64(float64(*lastRun.MaxCpuUsed) * 1.1)
+					mem = int64(float64(*lastRun.MaxMemoryUsed) * 1.25)
+				}
+			}
+		}
+	}
+
+	if cpu == state.MinCPU {
+		if run.Cpu != nil && *run.Cpu != 0 {
+			cpu = *run.Cpu
+		} else {
+			if definition.Cpu != nil && *definition.Cpu != 0 {
+				cpu = *definition.Cpu
+			}
+		}
+	}
+
+	if mem == state.MinMem {
+		if run.Memory != nil && *run.Memory != 0 {
+			mem = *run.Memory
+		} else {
+			if definition.Memory != nil && *definition.Memory != 0 {
+				mem = *definition.Memory
+			}
+		}
+	}
+
+	if mem >= 24576 && mem < 131072 && (definition.Gpu == nil || *definition.Gpu == 0) {
+		cpuOverride := mem / 8
+		if cpuOverride > cpu {
+			cpu = cpuOverride
+		}
+	}
+
+	return cpu, mem
 }
 
 func (a *eksAdapter) constructCmdSlice(cmdString string) []string {

--- a/execution/adapter/eks_adapter.go
+++ b/execution/adapter/eks_adapter.go
@@ -74,7 +74,6 @@ func (a *eksAdapter) AdaptJobToFlotillaRun(job *batchv1.Job, run state.Run, pod 
 	return updated, nil
 }
 
-
 func (a *eksAdapter) AdaptFlotillaDefinitionAndRunToJob(definition state.Definition, run state.Run, sa string, schedulerName string, manager state.Manager) (batchv1.Job, error) {
 	cmd := ""
 	if len(definition.Command) > 0 {
@@ -86,7 +85,7 @@ func (a *eksAdapter) AdaptFlotillaDefinitionAndRunToJob(definition state.Definit
 	}
 
 	cmdSlice := a.constructCmdSlice(cmd)
-	cmd = strings.Join(cmdSlice, "\n")
+	cmd = strings.Join(cmdSlice[3:], "\n")
 	run.Command = &cmd
 	resourceRequirements, run := a.constructResourceRequirements(definition, run, manager)
 

--- a/execution/engine/ecs_engine.go
+++ b/execution/engine/ecs_engine.go
@@ -310,7 +310,7 @@ func (ee *ECSExecutionEngine) Enqueue(run state.Run) error {
 // Execute takes a pre-configured run and definition and submits them for execution
 // to AWS ECS
 //
-func (ee *ECSExecutionEngine) Execute(definition state.Definition, run state.Run) (state.Run, bool, error) {
+func (ee *ECSExecutionEngine) Execute(definition state.Definition, run state.Run, manager state.Manager) (state.Run, bool, error) {
 	var executed state.Run
 	rti := ee.toRunTaskInput(definition, run)
 	result, err := ee.ecsClient.RunTask(&rti)

--- a/execution/engine/eks_engine.go
+++ b/execution/engine/eks_engine.go
@@ -155,7 +155,7 @@ func (ee *EKSExecutionEngine) getPodName(run state.Run) (state.Run, error) {
 	return run, nil
 }
 
-func (ee *EKSExecutionEngine) getInstanceDetails(pod v1.Pod, run state.Run) (state.Run) {
+func (ee *EKSExecutionEngine) getInstanceDetails(pod v1.Pod, run state.Run) state.Run {
 	if len(pod.Spec.NodeName) > 0 {
 		run.InstanceDNSName = pod.Spec.NodeName
 	}

--- a/execution/engine/eks_engine.go
+++ b/execution/engine/eks_engine.go
@@ -100,8 +100,8 @@ func (ee *EKSExecutionEngine) Initialize(conf config.Config) error {
 	return nil
 }
 
-func (ee *EKSExecutionEngine) Execute(td state.Definition, run state.Run) (state.Run, bool, error) {
-	job, err := ee.adapter.AdaptFlotillaDefinitionAndRunToJob(td, run, ee.jobSA, ee.schedulerName)
+func (ee *EKSExecutionEngine) Execute(td state.Definition, run state.Run, manager state.Manager) (state.Run, bool, error) {
+	job, err := ee.adapter.AdaptFlotillaDefinitionAndRunToJob(td, run, ee.jobSA, ee.schedulerName, manager)
 
 	result, err := ee.kClient.BatchV1().Jobs(ee.jobNamespace).Create(&job)
 	if err != nil {

--- a/execution/engine/engine.go
+++ b/execution/engine/engine.go
@@ -34,7 +34,7 @@ type Engine interface {
 
 	GetEvents(run state.Run) (state.PodEventList, error)
 
-	FetchUpdateStatus(run state.Run)(state.Run, error)
+	FetchUpdateStatus(run state.Run) (state.Run, error)
 }
 
 type RunReceipt struct {

--- a/execution/engine/engine.go
+++ b/execution/engine/engine.go
@@ -15,7 +15,7 @@ import (
 type Engine interface {
 	Initialize(conf config.Config) error
 	// v0
-	Execute(definition state.Definition, run state.Run) (state.Run, bool, error)
+	Execute(definition state.Definition, run state.Run, manager state.Manager) (state.Run, bool, error)
 
 	// v1 - once runs contain a copy of relevant definition info
 	// Execute(run state.Run) error

--- a/services/definition.go
+++ b/services/definition.go
@@ -62,6 +62,10 @@ func (ds *definitionService) Create(definition *state.Definition) (state.Definit
 		return state.Definition{}, exceptions.ConflictingResource{
 			fmt.Sprintf("definition with alias [%s] aleady exists", definition.Alias)}
 	}
+	ara := false
+	if definition.AdaptiveResourceAllocation == nil {
+		definition.AdaptiveResourceAllocation = &ara
+	}
 
 	// Attach definition id here
 	definitionID, err := state.NewDefinitionID(*definition)

--- a/services/execution_test.go
+++ b/services/execution_test.go
@@ -114,7 +114,6 @@ func TestExecutionService_Create(t *testing.T) {
 		}
 	}
 
-
 	includesExpected := false
 	for _, e := range *run.Env {
 		if e.Name == "K1" && e.Value == "V1" {

--- a/services/worker.go
+++ b/services/worker.go
@@ -14,7 +14,7 @@ type WorkerService interface {
 	List(engine string) (state.WorkersList, error)
 	Get(workerType string, engine string) (state.Worker, error)
 	Update(workerType string, updates state.Worker) (state.Worker, error)
-	BatchUpdate(updates []state.Worker, ) (state.WorkersList, error)
+	BatchUpdate(updates []state.Worker) (state.WorkersList, error)
 }
 
 type workerService struct {

--- a/state/manager.go
+++ b/state/manager.go
@@ -24,7 +24,7 @@ type Manager interface {
 	DeleteDefinition(definitionID string) error
 
 	ListRuns(limit int, offset int, sortBy string, order string, filters map[string][]string, envFilters map[string]string, engines []string) (RunList, error)
-	EstimateRunResources(definitionID string, command string)(TaskResources, error)
+	EstimateRunResources(definitionID string, command string) (TaskResources, error)
 
 	GetRun(runID string) (Run, error)
 	CreateRun(r Run) error

--- a/state/manager.go
+++ b/state/manager.go
@@ -24,7 +24,7 @@ type Manager interface {
 	DeleteDefinition(definitionID string) error
 
 	ListRuns(limit int, offset int, sortBy string, order string, filters map[string][]string, envFilters map[string]string, engines []string) (RunList, error)
-	GetRunResources(definitionID string, command string)(TaskResources, error)
+	EstimateRunResources(definitionID string, command string)(TaskResources, error)
 
 	GetRun(runID string) (Run, error)
 	CreateRun(r Run) error

--- a/state/manager.go
+++ b/state/manager.go
@@ -24,6 +24,7 @@ type Manager interface {
 	DeleteDefinition(definitionID string) error
 
 	ListRuns(limit int, offset int, sortBy string, order string, filters map[string][]string, envFilters map[string]string, engines []string) (RunList, error)
+	GetRunResources(definitionID string, command string)(TaskResources, error)
 
 	GetRun(runID string) (Run, error)
 	CreateRun(r Run) error

--- a/state/models.go
+++ b/state/models.go
@@ -587,3 +587,8 @@ type UserInfo struct {
 	Name  string `json:"name"`
 	Email string `json:"email"`
 }
+
+type TaskResources struct {
+	Cpu    int64 `json:"cpu"`
+	Memory int64 `json:"memory"`
+}

--- a/state/models.go
+++ b/state/models.go
@@ -17,9 +17,13 @@ var EKSEngine = "eks"
 
 var DefaultEngine = ECSEngine
 
-var MinCPU = int64(125)
+var MinCPU = int64(128)
 
-var MinMem = int64(125)
+var MaxCPU = int64(32000)
+
+var MinMem = int64(64)
+
+var MaxMem = int64(124000)
 
 var TTLSecondsAfterFinished = int32(3600)
 

--- a/state/models.go
+++ b/state/models.go
@@ -135,23 +135,24 @@ type Tags []string
 // - roughly 1-1 with an AWS ECS task definition
 //
 type Definition struct {
-	Arn              string     `json:"arn"`
-	DefinitionID     string     `json:"definition_id"`
-	Image            string     `json:"image"`
-	GroupName        string     `json:"group_name"`
-	ContainerName    string     `json:"container_name"`
-	User             string     `json:"user,omitempty"`
-	Alias            string     `json:"alias"`
-	Memory           *int64     `json:"memory"`
-	Gpu              *int64     `json:"gpu,omitempty"`
-	Cpu              *int64     `json:"cpu,omitempty"`
-	Command          string     `json:"command,omitempty"`
-	TaskType         string     `json:"-"`
-	Env              *EnvList   `json:"env"`
-	Ports            *PortsList `json:"ports,omitempty"`
-	Tags             *Tags      `json:"tags,omitempty"`
-	Privileged       *bool      `json:"privileged,omitempty"`
-	SharedMemorySize *int64     `json:"sharedMemorySize,omitempty"`
+	Arn                        string     `json:"arn"`
+	DefinitionID               string     `json:"definition_id"`
+	Image                      string     `json:"image"`
+	GroupName                  string     `json:"group_name"`
+	ContainerName              string     `json:"container_name"`
+	User                       string     `json:"user,omitempty"`
+	Alias                      string     `json:"alias"`
+	Memory                     *int64     `json:"memory"`
+	Gpu                        *int64     `json:"gpu,omitempty"`
+	Cpu                        *int64     `json:"cpu,omitempty"`
+	Command                    string     `json:"command,omitempty"`
+	TaskType                   string     `json:"-"`
+	Env                        *EnvList   `json:"env"`
+	Ports                      *PortsList `json:"ports,omitempty"`
+	Tags                       *Tags      `json:"tags,omitempty"`
+	Privileged                 *bool      `json:"privileged,omitempty"`
+	SharedMemorySize           *int64     `json:"sharedMemorySize,omitempty"`
+	AdaptiveResourceAllocation *bool      `json:"adaptiveResourceAllocation,omitempty"`
 }
 
 var commandWrapper = `
@@ -240,6 +241,9 @@ func (d *Definition) UpdateWith(other Definition) {
 	}
 	if other.Cpu != nil {
 		d.Cpu = other.Cpu
+	}
+	if other.AdaptiveResourceAllocation != nil {
+		d.AdaptiveResourceAllocation = other.AdaptiveResourceAllocation
 	}
 	if len(other.Command) > 0 {
 		d.Command = other.Command

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -183,8 +183,8 @@ const GetDefinitionSQL = DefinitionSelect + "\nwhere definition_id = $1"
 const GetDefinitionByAliasSQL = DefinitionSelect + "\nwhere alias = $1"
 
 const TaskResourcesSelectSQL = `
-SELECT (percentile_disc(0.99) within GROUP (ORDER BY max_memory_used) * 1.25)::numeric::integer as memory,
-       (percentile_disc(0.99) within GROUP (ORDER BY max_cpu_used) * 1.125)::numeric::integer   as cpu
+SELECT (percentile_disc(0.95) within GROUP (ORDER BY max_memory_used) * 1.125)::numeric::integer as memory,
+       (percentile_disc(0.95) within GROUP (ORDER BY max_cpu_used) * 1.05)::numeric::integer   as cpu
 FROM TASK
 WHERE definition_id = $1
   AND exit_code = 0

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -182,6 +182,16 @@ const GetDefinitionSQL = DefinitionSelect + "\nwhere definition_id = $1"
 //
 const GetDefinitionByAliasSQL = DefinitionSelect + "\nwhere alias = $1"
 
+const TaskResourcesSelectSQL = `
+SELECT (percentile_disc(0.99) within GROUP (ORDER BY max_memory_used) * 1.25)::numeric::integer as memory,
+       (percentile_disc(0.99) within GROUP (ORDER BY max_cpu_used) * 1.125)::numeric::integer   as cpu
+FROM TASK
+WHERE definition_id = $1
+  AND exit_code = 0
+  AND engine = 'eks'`
+
+const TaskResourcesSelectCommandSQL = TaskResourcesSelectSQL + "\n  AND command = $2"
+
 //
 // RunSelect postgres specific query for runs
 //
@@ -279,7 +289,6 @@ const WorkerSelect = `
 const ListWorkersSQL = WorkerSelect
 
 const GetWorkerEngine = WorkerSelect + "\nwhere engine = $1"
-
 
 //
 // GetWorkerSQL postgres specific query for retrieving data for a specific

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS task_def (
   container_name character varying NOT NULL,
   task_type character varying,
   privileged boolean,
-  adaptive_resource_allocation boolean
+  adaptive_resource_allocation boolean,
   -- Refactor these
   CONSTRAINT task_def_alias UNIQUE(alias)
 );

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS task_def (
   container_name character varying NOT NULL,
   task_type character varying,
   privileged boolean,
+  adaptive_resource_allocation boolean
   -- Refactor these
   CONSTRAINT task_def_alias UNIQUE(alias)
 );
@@ -138,6 +139,7 @@ const DefinitionSelect = `
 select
   coalesce(td.arn,'')       as arn,
   td.definition_id          as definitionid,
+  td.adaptive_resource_allocation as adaptiveresourceallocation,
   td.image                  as image,
   td.group_name             as groupname,
   td.container_name         as containername,

--- a/state/pg_state_manager.go
+++ b/state/pg_state_manager.go
@@ -26,7 +26,7 @@ type SQLStateManager struct {
 	db *sqlx.DB
 }
 
-func (sm *SQLStateManager) GetRunResources(definitionID string, command string) (TaskResources, error) {
+func (sm *SQLStateManager) EstimateRunResources(definitionID string, command string) (TaskResources, error) {
 	var err error
 	var taskResources TaskResources
 	if len(command) > 0 {

--- a/state/pg_state_manager.go
+++ b/state/pg_state_manager.go
@@ -247,7 +247,7 @@ func (sm *SQLStateManager) UpdateDefinition(definitionID string, updates Definit
       arn = $2, image = $3,
       container_name = $4, "user" = $5,
       alias = $6, memory = $7,
-      command = $8, env = $9, privileged = $10, cpu = $11, gpu = $12
+      command = $8, env = $9, privileged = $10, cpu = $11, gpu = $12, adaptive_resource_allocation = $13
     WHERE definition_id = $1;
     `
 
@@ -288,7 +288,7 @@ func (sm *SQLStateManager) UpdateDefinition(definitionID string, updates Definit
 		update, definitionID,
 		existing.Arn, existing.Image, existing.ContainerName,
 		existing.User, existing.Alias, existing.Memory,
-		existing.Command, existing.Env, existing.Privileged, existing.Cpu, existing.Gpu); err != nil {
+		existing.Command, existing.Env, existing.Privileged, existing.Cpu, existing.Gpu, existing.AdaptiveResourceAllocation); err != nil {
 		return existing, errors.Wrapf(err, "issue updating definition [%s]", definitionID)
 	}
 
@@ -329,9 +329,9 @@ func (sm *SQLStateManager) CreateDefinition(d Definition) error {
 	insert := `
     INSERT INTO task_def(
       arn, definition_id, image, group_name,
-      container_name, "user", alias, memory, command, env, privileged, cpu, gpu
+      container_name, "user", alias, memory, command, env, privileged, cpu, gpu, adaptive_resource_allocation
     )
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13);
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14);
     `
 
 	insertPorts := `
@@ -357,7 +357,7 @@ func (sm *SQLStateManager) CreateDefinition(d Definition) error {
 
 	if _, err = tx.Exec(insert,
 		d.Arn, d.DefinitionID, d.Image, d.GroupName, d.ContainerName,
-		d.User, d.Alias, d.Memory, d.Command, d.Env, d.Privileged, d.Cpu, d.Gpu); err != nil {
+		d.User, d.Alias, d.Memory, d.Command, d.Env, d.Privileged, d.Cpu, d.Gpu, d.AdaptiveResourceAllocation); err != nil {
 		tx.Rollback()
 		return errors.Wrapf(
 			err, "issue creating new task definition with alias [%s] and id [%s]", d.DefinitionID, d.Alias)

--- a/state/pg_state_manager_test.go
+++ b/state/pg_state_manager_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
 	"github.com/stitchfix/flotilla-os/config"
-
 )
 
 func getDB(conf config.Config) *sqlx.DB {
@@ -552,7 +551,7 @@ func TestSQLStateManager_CreateRun(t *testing.T) {
 		},
 		Command: &cmd,
 		Memory:  &mem,
-		Engine: &DefaultEngine,
+		Engine:  &DefaultEngine,
 	}
 	sm.CreateRun(r1)
 	sm.CreateRun(r2)

--- a/testutils/mocks.go
+++ b/testutils/mocks.go
@@ -350,7 +350,7 @@ func (iatt *ImplementsAllTheThings) PollStatus() (engine.RunReceipt, error) {
 }
 
 // Execute - Execution Engine
-func (iatt *ImplementsAllTheThings) Execute(definition state.Definition, run state.Run) (state.Run, bool, error) {
+func (iatt *ImplementsAllTheThings) Execute(definition state.Definition, run state.Run, manager state.Manager) (state.Run, bool, error) {
 	iatt.Calls = append(iatt.Calls, "Execute")
 	return state.Run{}, iatt.ExecuteErrorIsRetryable, iatt.ExecuteError
 }

--- a/testutils/mocks.go
+++ b/testutils/mocks.go
@@ -151,8 +151,8 @@ func (iatt *ImplementsAllTheThings) CreateRun(r state.Run) error {
 	return nil
 }
 
-func (iatt *ImplementsAllTheThings) GetRunResources(definitionID string, command string) (state.TaskResources, error) {
-	iatt.Calls = append(iatt.Calls, "GetRunResources")
+func (iatt *ImplementsAllTheThings) EstimateRunResources(definitionID string, command string) (state.TaskResources, error) {
+	iatt.Calls = append(iatt.Calls, "EstimateRunResources")
 	return state.TaskResources{}, nil
 }
 

--- a/testutils/mocks.go
+++ b/testutils/mocks.go
@@ -151,6 +151,11 @@ func (iatt *ImplementsAllTheThings) CreateRun(r state.Run) error {
 	return nil
 }
 
+func (iatt *ImplementsAllTheThings) GetRunResources(definitionID string, command string) (state.TaskResources, error) {
+	iatt.Calls = append(iatt.Calls, "GetRunResources")
+	return state.TaskResources{}, nil
+}
+
 // UpdateRun - StateManager
 func (iatt *ImplementsAllTheThings) UpdateRun(runID string, updates state.Run) (state.Run, error) {
 	iatt.Calls = append(iatt.Calls, "UpdateRun")

--- a/worker/status_worker.go
+++ b/worker/status_worker.go
@@ -42,7 +42,7 @@ func (sw *statusWorker) Initialize(conf config.Config, sm state.Manager, ee engi
 
 func (sw *statusWorker) setupRedisClient(conf config.Config) {
 	if *sw.engine == state.EKSEngine {
-		sw.redisClient = redis.NewClient(&redis.Options{Addr: conf.GetString("redis_address"), DB: conf.GetInt("redis_db"),})
+		sw.redisClient = redis.NewClient(&redis.Options{Addr: conf.GetString("redis_address"), DB: conf.GetInt("redis_db")})
 	}
 }
 

--- a/worker/status_worker.go
+++ b/worker/status_worker.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/go-redis/redis"
 	"math/rand"
-	"os"
 	"strings"
 	"time"
 
@@ -35,18 +34,16 @@ func (sw *statusWorker) Initialize(conf config.Config, sm state.Manager, ee engi
 	sw.ee = ee
 	sw.log = log
 	sw.engine = engine
-	hostname, err := os.Hostname()
-	if err != nil {
-		sw.workerId = fmt.Sprintf("%s-%d", hostname, rand.Int())
-	} else {
-		sw.workerId = fmt.Sprintf("%d", rand.Int())
-	}
+	sw.workerId = fmt.Sprintf("%d", rand.Int())
+	sw.setupRedisClient(conf)
+	_ = sw.log.Log("message", "initialized a status worker", "engine", *engine)
+	return nil
+}
 
+func (sw *statusWorker) setupRedisClient(conf config.Config) {
 	if *sw.engine == state.EKSEngine {
 		sw.redisClient = redis.NewClient(&redis.Options{Addr: conf.GetString("redis_address"), DB: conf.GetInt("redis_db"),})
 	}
-	_ = sw.log.Log("message", "initialized a status worker", "engine", *engine)
-	return nil
 }
 
 func (sw *statusWorker) GetTomb() *tomb.Tomb {
@@ -93,8 +90,6 @@ func (sw *statusWorker) runOnceEKS() {
 
 func (sw *statusWorker) processRuns(runs []state.Run) {
 	for _, run := range runs {
-		_ = sw.log.Log("message", "processEKSRuns", "run", run.RunID)
-
 		set, err := sw.redisClient.SetNX(run.RunID, sw.workerId, 20*time.Second).Result()
 		if err != nil {
 			_ = sw.log.Log("message", "unable to set lock", "error", fmt.Sprintf("%+v", err))
@@ -102,6 +97,7 @@ func (sw *statusWorker) processRuns(runs []state.Run) {
 		}
 
 		if set == true {
+			//_ = sw.log.Log("message", "processEKSRuns", "run", run.RunID)
 			sw.processRun(run)
 		}
 	}

--- a/worker/submit_worker.go
+++ b/worker/submit_worker.go
@@ -103,7 +103,7 @@ func (sw *submitWorker) runOnce() {
 			// Execute the run using the execution engine
 			//
 			sw.log.Log("message", "Submitting", "run_id", run.RunID)
-			launched, retryable, err := sw.ee.Execute(definition, run, nil)
+			launched, retryable, err := sw.ee.Execute(definition, run, sw.sm)
 			if err != nil {
 				sw.log.Log("message", "Error executing run", "run_id", run.RunID, "error", fmt.Sprintf("%+v", err), "retryable", retryable)
 				if !retryable {

--- a/worker/submit_worker.go
+++ b/worker/submit_worker.go
@@ -29,7 +29,7 @@ func (sw *submitWorker) Initialize(conf config.Config, sm state.Manager, ee engi
 	sw.ee = ee
 	sw.log = log
 	sw.engine = engine
-	sw.redisClient = redis.NewClient(&redis.Options{Addr: conf.GetString("redis_address"), DB: conf.GetInt("redis_db"),})
+	sw.redisClient = redis.NewClient(&redis.Options{Addr: conf.GetString("redis_address"), DB: conf.GetInt("redis_db")})
 	_ = sw.log.Log("message", "initialized a submit worker", "engine", *engine)
 	return nil
 }

--- a/worker/submit_worker.go
+++ b/worker/submit_worker.go
@@ -103,7 +103,7 @@ func (sw *submitWorker) runOnce() {
 			// Execute the run using the execution engine
 			//
 			sw.log.Log("message", "Submitting", "run_id", run.RunID)
-			launched, retryable, err := sw.ee.Execute(definition, run)
+			launched, retryable, err := sw.ee.Execute(definition, run, nil)
 			if err != nil {
 				sw.log.Log("message", "Error executing run", "run_id", run.RunID, "error", fmt.Sprintf("%+v", err), "retryable", retryable)
 				if !retryable {

--- a/worker/worker_manager.go
+++ b/worker/worker_manager.go
@@ -29,7 +29,7 @@ func (wm *workerManager) Initialize(conf config.Config, sm state.Manager, ee eng
 	wm.ee = ee
 	wm.sm = sm
 	wm.pollInterval = pollInterval
-    wm.engine = engine
+	wm.engine = engine
 	if err := wm.InitializeWorkers(); err != nil {
 		return errors.Errorf("WorkerManager unable to initialize workers. engine %s", *wm.engine)
 	}


### PR DESCRIPTION
Estimate resources to allocate to a run based on prior runs of the same task, command, and exit reason.

On a highlevel if `adaptive_resource_allocation` is enabled, it will allocated highest 95th percentile of the resources to a job