### PR TITLE
Template Wrapup

### DIFF
--- a/.migrations/V20200212101900__template.sql
+++ b/.migrations/V20200212101900__template.sql
@@ -1,0 +1,2 @@
+ALTER TABLE template ADD COLUMN default_payload JSONB;
+ALTER TABLE template ADD COLUMN avatar_uri VARCHAR;

--- a/execution/adapter/eks_adapter.go
+++ b/execution/adapter/eks_adapter.go
@@ -329,7 +329,7 @@ func (a *eksAdapter) getLastRun(manager state.Manager, run state.Run) state.Run 
 		},
 		"status":        {state.StatusStopped},
 		"command":       {strings.Replace(*run.Command, "'", "''", -1)},
-		"definition_id": {run.DefinitionID},
+		"executable_id": {*run.ExecutableID},
 	}, nil, []string{state.EKSEngine})
 	if err == nil && len(runList.Runs) > 0 {
 		lastRun = runList.Runs[0]

--- a/services/template.go
+++ b/services/template.go
@@ -143,7 +143,12 @@ func (ts *templateService) diff(prev state.Template, curr state.Template) bool {
 	if *prev.AdaptiveResourceAllocation != *curr.AdaptiveResourceAllocation {
 		return true
 	}
-	if prev.ContainerName != curr.ContainerName {
+
+	if reflect.DeepEqual(prev.DefaultPayload, curr.DefaultPayload) == false {
+		return true
+	}
+
+	if prev.AvatarURI != curr.AvatarURI {
 		return true
 	}
 
@@ -234,6 +239,16 @@ func (ts *templateService) constructTemplateFromCreateTemplateRequest(req *state
 	}
 	if req.Tags != nil {
 		tpl.Tags = req.Tags
+	}
+	if req.DefaultPayload != nil {
+		tpl.DefaultPayload = req.DefaultPayload
+	} else {
+		tpl.DefaultPayload = state.TemplatePayload{}
+	}
+	if len(req.AvatarURI) > 0 {
+		tpl.AvatarURI = req.AvatarURI
+	} else {
+		tpl.AvatarURI = ""
 	}
 
 	return tpl, nil

--- a/state/models.go
+++ b/state/models.go
@@ -778,8 +778,8 @@ type Template struct {
 	Version         int64              `json:"version"`
 	Schema          TemplateJSONSchema `json:"schema"`
 	CommandTemplate string             `json:"command_template"`
-	DefaultPayload  TemplatePayload    `json:"default_payload;omitempty"`
-	AvatarURI       string             `json:"avatar_uri;omitempty"`
+	DefaultPayload  TemplatePayload    `json:"default_payload"`
+	AvatarURI       string             `json:"avatar_uri"`
 	ExecutableResources
 }
 
@@ -787,18 +787,14 @@ type CreateTemplateRequest struct {
 	TemplateName    string             `json:"template_name"`
 	Schema          TemplateJSONSchema `json:"schema"`
 	CommandTemplate string             `json:"command_template"`
+	DefaultPayload  TemplatePayload    `json:"default_payload"`
+	AvatarURI       string             `json:"avatar_uri"`
 	ExecutableResources
 }
 
 type CreateTemplateResponse struct {
 	DidCreate bool     `json:"did_create"`
 	Template  Template `json:"template,omitempty"`
-}
-
-type TemplateUpdateRequest struct {
-	Schema          string `json:"schema"`
-	CommandTemplate string `json:"command_template"`
-	ExecutableResources
 }
 
 func (t Template) GetExecutableID() *string {

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -196,7 +196,9 @@ SELECT
   env::TEXT as env,
   privileged,
   cpu,
-  gpu
+  gpu,
+  default_payload as defaultpayload,
+  avatar_uri as avataruri
 FROM template
 `
 
@@ -222,7 +224,9 @@ const ListTemplatesLatestOnlySQL = `
     env::TEXT as env,
     privileged,
     cpu,
-    gpu
+    gpu,
+    default_payload as defaultpayload,
+    avatar_uri as avataruri
   FROM template
   ORDER BY template_name, version DESC, template_id
   LIMIT $1 OFFSET $2

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -225,7 +225,7 @@ const ListTemplatesLatestOnlySQL = `
     gpu
   FROM template
   ORDER BY template_name, version DESC, template_id
-  LIMIT $1 OFFSET $2;
+  LIMIT $1 OFFSET $2
 `
 
 // GetTemplateLatestOnlySQL get the latest version of a specific template name.

--- a/state/pg_state_manager.go
+++ b/state/pg_state_manager.go
@@ -1015,6 +1015,21 @@ func (tjs TemplateJSONSchema) Value() (driver.Value, error) {
 	return res, nil
 }
 
+// Scan from db
+func (tjs *TemplatePayload) Scan(value interface{}) error {
+	if value != nil {
+		s := []byte(value.([]uint8))
+		json.Unmarshal(s, &tjs)
+	}
+	return nil
+}
+
+// Value to db
+func (tjs TemplatePayload) Value() (driver.Value, error) {
+	res, _ := json.Marshal(tjs)
+	return res, nil
+}
+
 // GetTemplateByID returns a single template by id.
 func (sm *SQLStateManager) GetTemplateByID(templateID string) (Template, error) {
 	var err error
@@ -1099,9 +1114,9 @@ func (sm *SQLStateManager) CreateTemplate(t Template) error {
     INSERT INTO template(
 			template_id, template_name, version, schema, command_template,
 			adaptive_resource_allocation, image, container_name, memory, env,
-			privileged, cpu, gpu
+			privileged, cpu, gpu, default_payload, avatar_uri
     )
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13);
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15);
     `
 
 	tx, err := sm.db.Begin()
@@ -1112,7 +1127,7 @@ func (sm *SQLStateManager) CreateTemplate(t Template) error {
 	if _, err = tx.Exec(insert,
 		t.TemplateID, t.TemplateName, t.Version, t.Schema, t.CommandTemplate,
 		t.AdaptiveResourceAllocation, t.Image, t.ContainerName, t.Memory, t.Env,
-		t.Privileged, t.Cpu, t.Gpu); err != nil {
+		t.Privileged, t.Cpu, t.Gpu, t.DefaultPayload, t.AvatarURI); err != nil {
 		tx.Rollback()
 		return errors.Wrapf(
 			err, "issue creating new template with template_name [%s] and version [%d]", t.TemplateName, t.Version)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,9 +1,9 @@
 package utils
 
 import (
-	"fmt"
-	"github.com/pkg/errors"
 	"reflect"
+
+	"github.com/pkg/errors"
 )
 
 // StringSliceContains checks is a string slice contains a particular string.
@@ -28,7 +28,6 @@ func mergeMapsRecursive(a *map[string]interface{}, b map[string]interface{}) err
 	for k, v := range b {
 		// If the value is a map, check recursively.
 		if reflect.TypeOf(v).Kind() == reflect.Map {
-			fmt.Println("UGH")
 			if _, ok := (*a)[k]; !ok {
 				(*a)[k] = v
 			} else {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,5 +1,12 @@
 package utils
 
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"reflect"
+)
+
+// StringSliceContains checks is a string slice contains a particular string.
 func StringSliceContains(s []string, e string) bool {
 	for _, a := range s {
 		if a == e {
@@ -7,4 +14,41 @@ func StringSliceContains(s []string, e string) bool {
 		}
 	}
 	return false
+}
+
+// MergeMaps takes a pointer to a map (first arg) and map containing default
+// values (second arg) and recursively sets values that exist in `b` but are
+// not set in `a`. For existing values, it does not override those of `a` with
+// those of `b`.
+func MergeMaps(a *map[string]interface{}, b map[string]interface{}) error {
+	return mergeMapsRecursive(a, b)
+}
+
+func mergeMapsRecursive(a *map[string]interface{}, b map[string]interface{}) error {
+	for k, v := range b {
+		// If the value is a map, check recursively.
+		if reflect.TypeOf(v).Kind() == reflect.Map {
+			fmt.Println("UGH")
+			if _, ok := (*a)[k]; !ok {
+				(*a)[k] = v
+			} else {
+				aVal, ok := (*a)[k].(map[string]interface{})
+				bVal, ok := v.(map[string]interface{})
+
+				if !ok {
+					return errors.New("unable to cast interface{} to map[string]interface{}")
+				}
+
+				if err := mergeMapsRecursive(&aVal, bVal); err != nil {
+					return err
+				}
+			}
+		} else {
+			if _, ok := (*a)[k]; !ok {
+				(*a)[k] = v
+			}
+		}
+	}
+
+	return nil
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,88 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeMaps_Simple(t *testing.T) {
+	mapA := map[string]interface{}{
+		"A": "aaa",
+		"B": "bbb",
+		"C": "ccc",
+	}
+	mapB := map[string]interface{}{
+		"B": "xxx",
+		"D": "ddd",
+	}
+
+	expectedMapA := map[string]interface{}{
+		"A": "aaa",
+		"B": "bbb",
+		"C": "ccc",
+		"D": "ddd",
+	}
+
+	err := MergeMaps(&mapA, mapB)
+
+	if err != nil {
+		t.Error("unable to merge maps")
+	}
+
+	if reflect.DeepEqual(mapA, expectedMapA) == false {
+		t.Error("map merge unsuccessful")
+	}
+}
+
+func TestMergeMaps_Nested(t *testing.T) {
+	nestedAValue := "aaa"
+	nestedCValue := "ccc"
+	overrideNestedBVal := "zzzzzz"
+	nestedD1Value := "d1"
+	overrideNestedD1Value := "override_d1"
+	overrideNestedD2Value := "override_d2"
+
+	mapA := map[string]interface{}{
+		"Nested": map[string]interface{}{
+			"A": nestedAValue,
+			"C": nestedCValue,
+			"D": map[string]interface{}{
+				"D1": nestedD1Value,
+			},
+		},
+	}
+
+	mapB := map[string]interface{}{
+		"Nested": map[string]interface{}{
+			"B": overrideNestedBVal,
+			"D": map[string]interface{}{
+				"D1": overrideNestedD1Value,
+				"D2": overrideNestedD2Value,
+			},
+		},
+	}
+
+	// After merging, mapA should have its `B` value set. Additionally, mapA[D]
+	// should have its D2 value set BUT its D1 value should not be overriden.
+	expectedMapA := map[string]interface{}{
+		"Nested": map[string]interface{}{
+			"A": nestedAValue,
+			"B": overrideNestedBVal,
+			"C": nestedCValue,
+			"D": map[string]interface{}{
+				"D1": nestedD1Value,
+				"D2": overrideNestedD2Value,
+			},
+		},
+	}
+
+	err := MergeMaps(&mapA, mapB)
+
+	if err != nil {
+		t.Error("unable to merge maps")
+	}
+
+	if reflect.DeepEqual(mapA, expectedMapA) == false {
+		t.Error("map merge unsuccessful")
+	}
+}


### PR DESCRIPTION
This PR addresses a few issues with templates:
- `ListRuns` is now split into 3 separate methods: `ListRuns`, which lists runs for all executable types, `ListDefinitionRuns`, and `ListTemplateRuns`.
- The `ep.ListTemplates` method takes a `latest_only` URL param, which by default is set to true.
- Add `DefaultPayload` and `AvatarURI` fields to `Template` struct.
- Add `MergeMaps` helper function.