### PR TITLE
Make the status workers more deterministic

### DIFF
--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -69,7 +69,7 @@ FROM (SELECT max_memory_used, max_cpu_used
 const ListFailingNodesSQL = `
 SELECT instance_dns_name
       FROM TASK
-      WHERE (exit_code = 128 OR pod_events @> '[{"reason": "Failed"}]')
+      WHERE (exit_code = 128 OR pod_events @> '[{"reason": "Failed"}]' OR pod_events @> '[{"reason": "FailedSync"}]' OR  pod_events @> '[{"reason": "FailedCreatePodSandBox"}]')
            AND engine = 'eks'
            AND queued_at >= NOW() - INTERVAL '12 HOURS'
       GROUP BY 1

--- a/worker/status_worker.go
+++ b/worker/status_worker.go
@@ -75,9 +75,9 @@ func (sw *statusWorker) Run() error {
 }
 
 func (sw *statusWorker) runOnceEKS() {
-	rl, err := sw.sm.ListRuns(1000, 0, "status", "asc", map[string][]string{
+	rl, err := sw.sm.ListRuns(1000, 0, "queued_at", "asc", map[string][]string{
 		"queued_at_since": {
-			time.Now().AddDate(0, 0, -30).Format(time.RFC3339),
+			time.Now().AddDate(0, 0, -3).Format(time.RFC3339),
 		},
 		"status": {state.StatusNeedsRetry, state.StatusRunning, state.StatusQueued, state.StatusPending},
 	}, nil, []string{state.EKSEngine})
@@ -87,9 +87,6 @@ func (sw *statusWorker) runOnceEKS() {
 		return
 	}
 	runs := rl.Runs
-
-	rand.Seed(time.Now().UnixNano())
-	rand.Shuffle(len(runs), func(i, j int) { runs[i], runs[j] = runs[j], runs[i] })
 	sw.processEKSRuns(runs)
 }
 


### PR DESCRIPTION
- Remove shuffle for the list of runs
- use queued_at time to sort
- Reduce list to 3 days (improved query performance)

piggyback
- Adding more conditions to the failed query state.