### PR TITLE
Implement SQS based EKS event listener

### DIFF
--- a/execution/engine/ecs_engine.go
+++ b/execution/engine/ecs_engine.go
@@ -426,3 +426,6 @@ func (ee *ECSExecutionEngine) FetchUpdateStatus(run state.Run) (state.Run, error
 func (ee *ECSExecutionEngine) FetchPodMetrics(run state.Run) (state.Run, error) {
 	return run, nil
 }
+func (ee *ECSExecutionEngine) PollRunStatus() (state.Run, error) {
+	return state.Run{}, nil
+}

--- a/execution/engine/ecs_engine_test.go
+++ b/execution/engine/ecs_engine_test.go
@@ -41,6 +41,10 @@ func (mqm *mockQueueManager) ReceiveCloudTrail(qURL string) (state.CloudTrailS3F
 	return state.CloudTrailS3File{}, nil
 }
 
+func (mqm *mockQueueManager) ReceiveKubernetesRun(qURL string) (string, error) {
+	return "", nil
+}
+
 func (mqm *mockQueueManager) ReceiveStatus(qURL string) (queue.StatusReceipt, error) {
 	popped := mqm.statusUpdates[0]
 	mqm.statusUpdates = mqm.statusUpdates[1:]

--- a/execution/engine/engine.go
+++ b/execution/engine/engine.go
@@ -18,6 +18,7 @@ type Engine interface {
 	Terminate(run state.Run) error
 	Enqueue(run state.Run) error
 	PollRuns() ([]RunReceipt, error)
+	PollRunStatus() (state.Run, error)
 	PollStatus() (RunReceipt, error)
 	GetEvents(run state.Run) (state.PodEventList, error)
 	FetchUpdateStatus(run state.Run) (state.Run, error)

--- a/queue/manager.go
+++ b/queue/manager.go
@@ -18,6 +18,7 @@ type Manager interface {
 	ReceiveRun(qURL string) (RunReceipt, error)
 	ReceiveStatus(qURL string) (StatusReceipt, error)
 	ReceiveCloudTrail(qURL string) (state.CloudTrailS3File, error)
+	ReceiveKubernetesRun(queue string) (string, error)
 	List() ([]string, error)
 }
 

--- a/queue/sqs_manager.go
+++ b/queue/sqs_manager.go
@@ -292,6 +292,35 @@ func (qm *SQSManager) ReceiveCloudTrail(qURL string) (state.CloudTrailS3File, er
 	return receipt, nil
 }
 
+func (qm *SQSManager) ReceiveKubernetesRun(queue string) (string, error) {
+	var runId string
+
+	qURL, err := qm.QurlFor(queue, false)
+	if len(qURL) == 0 || err != nil {
+		return runId, errors.Errorf("no queue url specified, can't dequeue")
+	}
+
+	maxMessages := int64(1)
+	visibilityTimeout := int64(45)
+	rmi := sqs.ReceiveMessageInput{
+		QueueUrl:            &qURL,
+		MaxNumberOfMessages: &maxMessages,
+		VisibilityTimeout:   &visibilityTimeout,
+	}
+
+	response, err := qm.qc.ReceiveMessage(&rmi)
+	if err != nil {
+		return runId, errors.Wrapf(err, "problem receiving sqs message from queue url [%s]", qURL)
+	}
+
+	if response != nil && response.Messages != nil && len(response.Messages) > 0 && response.Messages[0].Body != nil {
+		runId = *response.Messages[0].Body
+		_ = qm.ack(qURL, response.Messages[0].ReceiptHandle)
+
+	}
+	return runId, nil
+}
+
 //
 // Ack acknowledges the receipt -AND- processing of the
 // the message referred to by handle

--- a/queue/sqs_manager.go
+++ b/queue/sqs_manager.go
@@ -314,11 +314,11 @@ func (qm *SQSManager) ReceiveKubernetesRun(queue string) (string, error) {
 	}
 
 	if response != nil && response.Messages != nil && len(response.Messages) > 0 && response.Messages[0].Body != nil {
-		runId = *response.Messages[0].Body
 		_ = qm.ack(qURL, response.Messages[0].ReceiptHandle)
-
+		return *response.Messages[0].Body, nil
 	}
-	return runId, nil
+
+	return runId, errors.Wrapf(err, "no message")
 }
 
 //

--- a/testutils/mocks.go
+++ b/testutils/mocks.go
@@ -324,6 +324,11 @@ func (iatt *ImplementsAllTheThings) IsImageValid(imageRef string) (bool, error) 
 	return true, nil
 }
 
+func (iatt *ImplementsAllTheThings) PollRunStatus() (state.Run, error) {
+	iatt.Calls = append(iatt.Calls, "PollRunStatus")
+	return state.Run{}, nil
+}
+
 // PollRuns - Execution Engine
 func (iatt *ImplementsAllTheThings) PollRuns() ([]engine.RunReceipt, error) {
 	iatt.Calls = append(iatt.Calls, "PollRuns")

--- a/worker/status_eks.go
+++ b/worker/status_eks.go
@@ -1,0 +1,136 @@
+package worker
+
+import (
+	"fmt"
+	"github.com/go-redis/redis"
+	"github.com/stitchfix/flotilla-os/queue"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/stitchfix/flotilla-os/config"
+	"github.com/stitchfix/flotilla-os/execution/engine"
+	flotillaLog "github.com/stitchfix/flotilla-os/log"
+	"github.com/stitchfix/flotilla-os/state"
+	"gopkg.in/tomb.v2"
+)
+
+type statusEKSWorker struct {
+	sm           state.Manager
+	ee           engine.Engine
+	conf         config.Config
+	log          flotillaLog.Logger
+	pollInterval time.Duration
+	t            tomb.Tomb
+	engine       *string
+	redisClient  *redis.Client
+	workerId     string
+}
+
+func (sw *statusEKSWorker) Initialize(conf config.Config, sm state.Manager, ee engine.Engine, log flotillaLog.Logger, pollInterval time.Duration, engine *string, qm queue.Manager) error {
+	sw.pollInterval = pollInterval
+	sw.conf = conf
+	sw.sm = sm
+	sw.ee = ee
+	sw.log = log
+	sw.engine = engine
+	sw.workerId = fmt.Sprintf("%d", rand.Int())
+	sw.setupRedisClient(conf)
+	_ = sw.log.Log("message", "initialized a status worker", "engine", *engine)
+	return nil
+}
+
+func (sw *statusEKSWorker) setupRedisClient(conf config.Config) {
+	if *sw.engine == state.EKSEngine {
+		sw.redisClient = redis.NewClient(&redis.Options{Addr: conf.GetString("redis_address"), DB: conf.GetInt("redis_db")})
+	}
+}
+
+func (sw *statusEKSWorker) GetTomb() *tomb.Tomb {
+	return &sw.t
+}
+
+//
+// Run updates status of tasks
+//
+func (sw *statusEKSWorker) Run() error {
+	for {
+		select {
+		case <-sw.t.Dying():
+			_ = sw.log.Log("message", "A status worker was terminated")
+			return nil
+		default:
+			if *sw.engine == state.EKSEngine {
+				sw.runOnceEKS()
+				time.Sleep(sw.pollInterval)
+			}
+		}
+	}
+}
+
+func (sw *statusEKSWorker) runOnceEKS() {
+	run, err := sw.ee.PollRunStatus()
+	if err == nil {
+		sw.processEKSRun(run)
+	}
+}
+
+func (sw *statusEKSWorker) processEKSRun(run state.Run) {
+	reloadRun, err := sw.sm.GetRun(run.RunID)
+	if err == nil && reloadRun.Status == state.StatusStopped {
+		return
+	}
+	if err != nil {
+		_ = sw.log.Log("message", "run not found", "error", err)
+		return
+	}
+
+	run = reloadRun
+	updatedRun, err := sw.ee.FetchUpdateStatus(run)
+	if err != nil {
+		message := fmt.Sprintf("%+v", err)
+		_ = sw.log.Log("message", "unable to receive eks runs", "error", message)
+
+		minutesInQueue := time.Now().Sub(*run.QueuedAt).Minutes()
+		if strings.Contains(message, "not found") && minutesInQueue > float64(30) {
+			stoppedAt := time.Now()
+			reason := "Job either timed out or not found on the EKS cluster."
+			updatedRun.Status = state.StatusStopped
+			updatedRun.FinishedAt = &stoppedAt
+			updatedRun.ExitReason = &reason
+			_, err = sw.sm.UpdateRun(updatedRun.RunID, updatedRun)
+		}
+
+	} else {
+		if run.Status != updatedRun.Status {
+			_ = sw.log.Log("message", "updating eks run", "run", updatedRun.RunID, "status", updatedRun.Status)
+			_, err = sw.sm.UpdateRun(updatedRun.RunID, updatedRun)
+			if err != nil {
+				_ = sw.log.Log("message", "unable to save eks runs", "error", fmt.Sprintf("%+v", err))
+			}
+
+			if updatedRun.Status == state.StatusStopped {
+				//TODO - move to a separate worker.
+				//_ = sw.ee.Terminate(run)
+			}
+		} else {
+			if updatedRun.MaxMemoryUsed != run.MaxMemoryUsed ||
+				updatedRun.MaxCpuUsed != run.MaxCpuUsed ||
+				updatedRun.Cpu != run.Cpu ||
+				updatedRun.Memory != run.Memory ||
+				updatedRun.PodEvents != run.PodEvents {
+				_, err = sw.sm.UpdateRun(updatedRun.RunID, updatedRun)
+			}
+		}
+	}
+}
+
+func (sw *statusEKSWorker) processEKSRunMetrics(run state.Run) {
+	updatedRun, err := sw.ee.FetchPodMetrics(run)
+	if err == nil {
+		if updatedRun.MaxMemoryUsed != run.MaxMemoryUsed ||
+			updatedRun.MaxCpuUsed != run.MaxCpuUsed {
+			_, err = sw.sm.UpdateRun(updatedRun.RunID, updatedRun)
+		}
+	}
+}

--- a/worker/status_worker.go
+++ b/worker/status_worker.go
@@ -170,6 +170,7 @@ func (sw *statusWorker) processEKSRunMetrics(run state.Run) {
 
 func (sw *statusWorker) runOnceECS() {
 	runReceipt, err := sw.ee.PollStatus()
+
 	if err != nil {
 		sw.log.Log("message", "unable to receive status message", "error", fmt.Sprintf("%+v", err))
 		return

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -39,6 +39,8 @@ func NewWorker(workerType string, log flotillaLog.Logger, conf config.Config, ee
 		worker = &workerManager{engine: engine}
 	case "cloudtrail":
 		worker = &cloudtrailWorker{engine: engine}
+	case "status_eks":
+		worker = &statusEKSWorker{engine: engine}
 	default:
 		return nil, errors.Errorf("no workerType [%s] exists", workerType)
 	}


### PR DESCRIPTION
Adding an SQS based status worker for EKS. 

The worker listens to the SQS queue for run_ids and then updates the status of the jobs. The events are triggered on pod updates.