### PR TITLE
adding ability to validate (dry_run) templates

### DIFF
--- a/flotilla/endpoints.go
+++ b/flotilla/endpoints.go
@@ -919,7 +919,14 @@ func (ep *endpoints) getStringBoolVal(s string) bool {
 // Create a new template run based on template name/alias.
 func (ep *endpoints) CreateTemplateRunByName(w http.ResponseWriter, r *http.Request) {
 	var req state.TemplateExecutionRequest
-	err := ep.decodeRequest(r, &req)
+	queryParams := r.URL.Query()
+	dryRun, err := strconv.ParseBool(queryParams.Get("dry_run"))
+
+	if err != nil {
+		dryRun = false
+	}
+
+	err = ep.decodeRequest(r, &req)
 
 	if err != nil {
 		ep.encodeError(w, exceptions.MalformedInput{ErrorString: err.Error()})
@@ -953,7 +960,7 @@ func (ep *endpoints) CreateTemplateRunByName(w http.ResponseWriter, r *http.Requ
 	}
 	vars := mux.Vars(r)
 
-	run, err := ep.executionService.CreateTemplateRunByTemplateName(vars["template_name"], vars["template_version"], &req)
+	run, err := ep.executionService.CreateTemplateRunByTemplateName(vars["template_name"], vars["template_version"], &req, dryRun)
 	if err != nil {
 		ep.logger.Log(
 			"message", "problem creating template run",
@@ -969,7 +976,14 @@ func (ep *endpoints) CreateTemplateRunByName(w http.ResponseWriter, r *http.Requ
 // Create a new template run based on template id.
 func (ep *endpoints) CreateTemplateRun(w http.ResponseWriter, r *http.Request) {
 	var req state.TemplateExecutionRequest
-	err := ep.decodeRequest(r, &req)
+	queryParams := r.URL.Query()
+	dryRun, err := strconv.ParseBool(queryParams.Get("dry_run"))
+
+	if err != nil {
+		dryRun = false
+	}
+
+	err = ep.decodeRequest(r, &req)
 
 	if err != nil {
 		ep.encodeError(w, exceptions.MalformedInput{ErrorString: err.Error()})
@@ -1003,7 +1017,7 @@ func (ep *endpoints) CreateTemplateRun(w http.ResponseWriter, r *http.Request) {
 	}
 	vars := mux.Vars(r)
 
-	run, err := ep.executionService.CreateTemplateRunByTemplateID(vars["template_id"], &req)
+	run, err := ep.executionService.CreateTemplateRunByTemplateID(vars["template_id"], &req, dryRun)
 	if err != nil {
 		ep.logger.Log(
 			"message", "problem creating template run",

--- a/services/execution.go
+++ b/services/execution.go
@@ -39,8 +39,8 @@ type ExecutionService interface {
 	ReservedVariables() []string
 	ListClusters() ([]string, error)
 	GetEvents(run state.Run) (state.PodEventList, error)
-	CreateTemplateRunByTemplateID(templateID string, req *state.TemplateExecutionRequest) (state.Run, error)
-	CreateTemplateRunByTemplateName(templateName string, templateVersion string, req *state.TemplateExecutionRequest) (state.Run, error)
+	CreateTemplateRunByTemplateID(templateID string, req *state.TemplateExecutionRequest, dryRun bool) (state.Run, error)
+	CreateTemplateRunByTemplateName(templateName string, templateVersion string, req *state.TemplateExecutionRequest, dryRun bool) (state.Run, error)
 }
 
 type executionService struct {
@@ -499,19 +499,19 @@ func (es *executionService) createAndEnqueueRun(run state.Run) (state.Run, error
 
 	return run, nil
 }
-func (es *executionService) CreateTemplateRunByTemplateName(templateName string, templateVersion string, req *state.TemplateExecutionRequest) (state.Run, error) {
+func (es *executionService) CreateTemplateRunByTemplateName(templateName string, templateVersion string, req *state.TemplateExecutionRequest, dryRun bool) (state.Run, error) {
 	version, err := strconv.Atoi(templateVersion)
 
 	if err != nil {
 		//use the "latest" template - version not a integer
 		fetch, template, err := es.stateManager.GetLatestTemplateByTemplateName(templateName)
 		if fetch && err == nil {
-			return es.CreateTemplateRunByTemplateID(template.TemplateID, req)
+			return es.CreateTemplateRunByTemplateID(template.TemplateID, req, dryRun)
 		}
 	} else {
 		fetch, template, err := es.stateManager.GetTemplateByVersion(templateName, int64(version))
 		if fetch && err == nil {
-			return es.CreateTemplateRunByTemplateID(template.TemplateID, req)
+			return es.CreateTemplateRunByTemplateID(template.TemplateID, req, dryRun)
 		}
 	}
 	return state.Run{},
@@ -521,17 +521,17 @@ func (es *executionService) CreateTemplateRunByTemplateName(templateName string,
 //
 // Create constructs and queues a new Run on the cluster specified.
 //
-func (es *executionService) CreateTemplateRunByTemplateID(templateID string, req *state.TemplateExecutionRequest) (state.Run, error) {
+func (es *executionService) CreateTemplateRunByTemplateID(templateID string, req *state.TemplateExecutionRequest, dryRun bool) (state.Run, error) {
 	// Ensure template exists
 	template, err := es.stateManager.GetTemplateByID(templateID)
 	if err != nil {
 		return state.Run{}, err
 	}
 
-	return es.createFromTemplate(template, req)
+	return es.createFromTemplate(template, req, dryRun)
 }
 
-func (es *executionService) createFromTemplate(template state.Template, req *state.TemplateExecutionRequest) (state.Run, error) {
+func (es *executionService) createFromTemplate(template state.Template, req *state.TemplateExecutionRequest, dryRun bool) (state.Run, error) {
 	var (
 		run state.Run
 		err error
@@ -550,8 +550,10 @@ func (es *executionService) createFromTemplate(template state.Template, req *sta
 	if err != nil {
 		return run, err
 	}
-
-	return es.createAndEnqueueRun(run)
+	if ! dryRun {
+		return es.createAndEnqueueRun(run)
+	}
+	return run, nil
 }
 
 func (es *executionService) constructRunFromTemplate(template state.Template, req *state.TemplateExecutionRequest) (state.Run, error) {


### PR DESCRIPTION
`/template/name/{template_name}/version/{template_version}/execute?dry_run=true` will  not submit the job to EKS/ECS, just ensure that the template params are runnable.