### PR TITLE
Adding EKS pod attempt count to the get run api

### DIFF
--- a/.migrations/V20200325125200__add_attempts.sql
+++ b/.migrations/V20200325125200__add_attempts.sql
@@ -1,0 +1,1 @@
+ALTER TABLE task ADD COLUMN attempt_count integer;

--- a/execution/engine/eks_engine.go
+++ b/execution/engine/eks_engine.go
@@ -511,6 +511,16 @@ func (ee *EKSExecutionEngine) FetchUpdateStatus(run state.Run) (state.Run, error
 		}
 	}
 
+	if run.PodEvents != nil {
+		attemptCount := int64(0)
+		for _, podEvent := range *run.PodEvents {
+			if strings.Contains(podEvent.Reason, "Scheduled") {
+				attemptCount = attemptCount + 1
+			}
+		}
+		run.AttemptCount = &attemptCount
+	}
+
 	// Handle edge case for dangling jobs.
 	// Run used to have a pod and now it is not there, job is older than 24 hours. Terminate it.
 	if err == nil && podList != nil && podList.Items != nil && len(podList.Items) == 0 && run.PodName != nil && run.QueuedAt.Before(hoursBack) {

--- a/state/models.go
+++ b/state/models.go
@@ -443,6 +443,7 @@ type Run struct {
 	ExecutableID            *string                  `json:"executable_id,omitempty"`
 	ExecutableType          *ExecutableType          `json:"executable_type,omitempty"`
 	ExecutionRequestCustom  *ExecutionRequestCustom  `json:"execution_request_custom,omitempty"`
+	AttemptCount            *int64                   `json:"attempt_count,omitempty"`
 }
 
 //
@@ -580,6 +581,10 @@ func (d *Run) UpdateWith(other Run) {
 
 	if other.MemoryLimit != nil {
 		d.MemoryLimit = other.MemoryLimit
+	}
+
+	if other.AttemptCount != nil {
+		d.AttemptCount = other.AttemptCount
 	}
 	//
 	// Runs have a deterministic lifecycle

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -117,7 +117,8 @@ select
   coalesce(executable_type,'') as executabletype,
   execution_request_custom::TEXT as executionrequestcustom,
   cpu_limit as cpulimit,
-  memory_limit as memorylimit
+  memory_limit as memorylimit,
+  attempt_count as attemptcount
 from task t
 `
 

--- a/state/pg_state_manager.go
+++ b/state/pg_state_manager.go
@@ -563,7 +563,7 @@ func (sm *SQLStateManager) UpdateRun(runID string, updates Run) (Run, error) {
 			&existing.Cpu, &existing.Gpu, &existing.Engine, &existing.EphemeralStorage, &existing.NodeLifecycle,
 			&existing.ContainerName, &existing.PodName, &existing.Namespace, &existing.MaxCpuUsed, &existing.MaxMemoryUsed,
 			&existing.PodEvents, &existing.CommandHash, &existing.CloudTrailNotifications, &existing.ExecutableID,
-			&existing.ExecutableType, &existing.ExecutionRequestCustom, &existing.CpuLimit, &existing.MemoryLimit)
+			&existing.ExecutableType, &existing.ExecutionRequestCustom, &existing.CpuLimit, &existing.MemoryLimit, &existing.AttemptCount)
 	}
 	if err != nil {
 		return existing, errors.WithStack(err)
@@ -585,7 +585,7 @@ func (sm *SQLStateManager) UpdateRun(runID string, updates Run) (Run, error) {
 	  command = $17, memory = $18, cpu = $19, gpu = $20, engine = $21, ephemeral_storage = $22, node_lifecycle = $23,
 	  container_name = $24, pod_name = $25, namespace = $26, max_cpu_used = $27, max_memory_used = $28, pod_events = $29,
 	  cloudtrail_notifications = $30, executable_id = $31, executable_type = $32, execution_request_custom = $33,
-	  cpu_limit = $34, memory_limit = $35
+	  cpu_limit = $34, memory_limit = $35, attempt_count = $36
     WHERE run_id = $1;
     `
 
@@ -604,7 +604,7 @@ func (sm *SQLStateManager) UpdateRun(runID string, updates Run) (Run, error) {
 		existing.ContainerName, existing.PodName, existing.Namespace, existing.MaxCpuUsed,
 		existing.MaxMemoryUsed, existing.PodEvents, existing.CloudTrailNotifications,
 		existing.ExecutableID, existing.ExecutableType, existing.ExecutionRequestCustom,
-		existing.CpuLimit, existing.MemoryLimit); err != nil {
+		existing.CpuLimit, existing.MemoryLimit, existing.AttemptCount); err != nil {
 		tx.Rollback()
 		return existing, errors.WithStack(err)
 	}
@@ -627,10 +627,10 @@ func (sm *SQLStateManager) CreateRun(r Run) error {
       queued_at, started_at, finished_at, instance_id, instance_dns_name, group_name,
       env, task_type, command, memory, cpu, gpu, engine, node_lifecycle, ephemeral_storage,
 			container_name, pod_name, namespace, max_cpu_used, max_memory_used, pod_events, command_hash,
-			executable_id, executable_type, execution_request_custom, cpu_limit, memory_limit
+			executable_id, executable_type, execution_request_custom, cpu_limit, memory_limit, attempt_count
     ) VALUES (
       $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, 'task', $17, $18, $19, $20, $21, $22, $23,
-      $24, $25, $26, $27, $28, $29, MD5($17), $30, $31, $32, $33, $34);
+      $24, $25, $26, $27, $28, $29, MD5($17), $30, $31, $32, $33, $34, $35);
     `
 
 	tx, err := sm.db.Begin()
@@ -647,7 +647,7 @@ func (sm *SQLStateManager) CreateRun(r Run) error {
 		r.Env, r.Command, r.Memory, r.Cpu, r.Gpu, r.Engine, r.NodeLifecycle,
 		r.EphemeralStorage, r.ContainerName, r.PodName, r.Namespace, r.MaxCpuUsed,
 		r.MaxMemoryUsed, r.PodEvents, r.ExecutableID, r.ExecutableType,
-		r.ExecutionRequestCustom, r.CpuLimit, r.MemoryLimit); err != nil {
+		r.ExecutionRequestCustom, r.CpuLimit, r.MemoryLimit, r.AttemptCount); err != nil {
 		tx.Rollback()
 		return errors.Wrapf(err, "issue creating new task run with id [%s]", r.RunID)
 	}


### PR DESCRIPTION
A pod may get scheduled multiple times, especially when the underlying node gets terminated. For instance AWS spot terminations.

```
{"reason": "Scheduled",
 "message": "Successfully assigned flotilla/eks-030a-d76a-407c-4eb3-05f0efaf6f61-dfpsc to ip-10-222-222-222.ec2.internal"...
```

This PR surfaces out the number of times a pod has been *Scheduled* as `attempt_count`

