### PR TITLE
Adding override for node-type based on spot re attempt rate

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,9 @@ type Config interface {
 	GetStringMapString(key string) map[string]string
 	GetInt(key string) int
 	GetBool(key string) bool
+	GetFloat64(key string) float64
 	IsSet(key string) bool
+
 }
 
 //
@@ -48,6 +50,11 @@ type conf struct {
 // GetString returns the value associated with the key as a string.
 func (c *conf) GetString(key string) string {
 	return c.v.GetString(key)
+}
+
+// GetFloat returns the value associated with the key as a float.
+func (c *conf) GetFloat64(key string) float64 {
+	return c.v.GetFloat64(key)
 }
 
 // GetInt returns the value associated with the key as an integer.

--- a/execution/adapter/eks_adapter.go
+++ b/execution/adapter/eks_adapter.go
@@ -168,7 +168,6 @@ func (a *eksAdapter) constructAffinity(executable state.Executable, run state.Ru
 	cpuNodeTypes := []string{"c5.2xlarge", "c5.4xlarge", "c5.9xlarge"}
 
 	var nodeLifecycle []string
-
 	if *run.NodeLifecycle == state.OndemandLifecycle {
 		nodeLifecycle = append(nodeLifecycle, "normal")
 	} else {

--- a/execution/adapter/eks_adapter.go
+++ b/execution/adapter/eks_adapter.go
@@ -168,6 +168,7 @@ func (a *eksAdapter) constructAffinity(executable state.Executable, run state.Ru
 	cpuNodeTypes := []string{"c5.2xlarge", "c5.4xlarge", "c5.9xlarge"}
 
 	var nodeLifecycle []string
+
 	if *run.NodeLifecycle == state.OndemandLifecycle {
 		nodeLifecycle = append(nodeLifecycle, "normal")
 	} else {

--- a/services/execution.go
+++ b/services/execution.go
@@ -241,6 +241,8 @@ func (es *executionService) constructBaseRunFromExecutable(executable state.Exec
 
 	reAttemptRate, _ := es.stateManager.GetPodReAttemptRate()
 	if reAttemptRate >= es.spotReAttemptOverride &&
+		fields.Engine != nil &&
+		fields.NodeLifecycle != nil &&
 		*fields.Engine == state.EKSEngine &&
 		*fields.NodeLifecycle == state.SpotLifecycle {
 		fields.NodeLifecycle = &state.OndemandLifecycle

--- a/services/execution.go
+++ b/services/execution.go
@@ -242,7 +242,7 @@ func (es *executionService) constructBaseRunFromExecutable(executable state.Exec
 	reAttemptRate, _ := es.stateManager.GetPodReAttemptRate()
 	if reAttemptRate >= es.spotReAttemptOverride &&
 		*fields.Engine == state.EKSEngine &&
-		*fields.NodeLifecycle == state.OndemandLifecycle {
+		*fields.NodeLifecycle == state.SpotLifecycle {
 		fields.NodeLifecycle = &state.OndemandLifecycle
 	}
 

--- a/services/execution.go
+++ b/services/execution.go
@@ -240,7 +240,7 @@ func (es *executionService) constructBaseRunFromExecutable(executable state.Exec
 	}
 
 	reAttemptRate, _ := es.stateManager.GetPodReAttemptRate()
-	if reAttemptRate >= es.spotReAttemptOverride {
+	if reAttemptRate >= es.spotReAttemptOverride && *fields.Engine == state.EKSEngine {
 		fields.NodeLifecycle = &state.OndemandLifecycle
 	}
 

--- a/services/execution.go
+++ b/services/execution.go
@@ -240,7 +240,9 @@ func (es *executionService) constructBaseRunFromExecutable(executable state.Exec
 	}
 
 	reAttemptRate, _ := es.stateManager.GetPodReAttemptRate()
-	if reAttemptRate >= es.spotReAttemptOverride && *fields.Engine == state.EKSEngine {
+	if reAttemptRate >= es.spotReAttemptOverride &&
+		*fields.Engine == state.EKSEngine &&
+		*fields.NodeLifecycle == state.OndemandLifecycle {
 		fields.NodeLifecycle = &state.OndemandLifecycle
 	}
 

--- a/services/execution_test.go
+++ b/services/execution_test.go
@@ -38,12 +38,13 @@ func TestExecutionService_CreateDefinitionRunByDefinitionID(t *testing.T) {
 		{Name: "K1", Value: "V1"},
 	}
 	expectedCalls := map[string]bool{
-		"GetDefinition": true,
-		"IsImageValid":  true,
-		"CanBeRun":      true,
-		"CreateRun":     true,
-		"UpdateRun":     true,
-		"Enqueue":       true,
+		"GetDefinition":       true,
+		"IsImageValid":        true,
+		"CanBeRun":            true,
+		"CreateRun":           true,
+		"UpdateRun":           true,
+		"GetPodReAttemptRate": true,
+		"Enqueue":             true,
 	}
 
 	cmd := "_test_cmd_"

--- a/services/execution_test.go
+++ b/services/execution_test.go
@@ -152,6 +152,7 @@ func TestExecutionService_CreateDefinitionRunByAlias(t *testing.T) {
 		"CanBeRun":             true,
 		"CreateRun":            true,
 		"UpdateRun":            true,
+		"GetPodReAttemptRate":  true,
 		"Enqueue":              true,
 	}
 	mem := int64(1024)

--- a/state/manager.go
+++ b/state/manager.go
@@ -48,6 +48,7 @@ type Manager interface {
 	CreateTemplate(t Template) error
 
 	ListFailingNodes() (NodeList, error)
+	GetPodReAttemptRate() (float32, error)
 }
 
 //

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -75,6 +75,17 @@ SELECT instance_dns_name
       GROUP BY 1
 `
 
+const PodReAttemptRate = `
+SELECT (multiple_attempts / (CASE WHEN single_attempts = 0 THEN 1 ELSE single_attempts END)) AS attempts
+FROM (
+      SELECT COUNT(CASE WHEN attempt_count = 1 THEN 1 END) * 1.0 AS single_attempts,
+             COUNT(CASE WHEN attempt_count != 1 THEN 1 END) * 1.0 AS multiple_attempts
+      FROM task
+      WHERE engine = 'eks' AND
+            queued_at >= NOW() - INTERVAL '3 HOURS' AND
+            node_lifecycle = 'spot') A
+`
+
 //
 // RunSelect postgres specific query for runs
 //

--- a/state/pg_state_manager.go
+++ b/state/pg_state_manager.go
@@ -43,6 +43,22 @@ func (sm *SQLStateManager) ListFailingNodes() (NodeList, error) {
 	return nodeList, err
 }
 
+func (sm *SQLStateManager) GetPodReAttemptRate() (float32, error) {
+	var err error
+	attemptRate := float32(1.0)
+	err = sm.db.Get(&attemptRate, PodReAttemptRate)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return attemptRate, exceptions.MissingResource{
+				ErrorString: fmt.Sprintf("Error fetching attempt rate")}
+		} else {
+			return attemptRate, errors.Wrapf(err, "Error fetching attempt rate")
+		}
+	}
+	return attemptRate, err
+}
+
 func (sm *SQLStateManager) EstimateRunResources(executableID string, runID string) (TaskResources, error) {
 	var err error
 	var taskResources TaskResources

--- a/testutils/mocks.go
+++ b/testutils/mocks.go
@@ -75,7 +75,7 @@ func (iatt *ImplementsAllTheThings) ListFailingNodes() (state.NodeList, error) {
 
 func (iatt *ImplementsAllTheThings) GetPodReAttemptRate() (float32, error) {
 	iatt.Calls = append(iatt.Calls, "GetPodReAttemptRate")
-	return 0.0, nil
+	return 1.0, nil
 }
 
 // ListDefinitions - StateManager

--- a/testutils/mocks.go
+++ b/testutils/mocks.go
@@ -73,6 +73,11 @@ func (iatt *ImplementsAllTheThings) ListFailingNodes() (state.NodeList, error) {
 	return nodeList, nil
 }
 
+func (iatt *ImplementsAllTheThings) GetPodReAttemptRate() (float32, error) {
+	iatt.Calls = append(iatt.Calls, "GetPodReAttemptRate")
+	return 0.0, nil
+}
+
 // ListDefinitions - StateManager
 func (iatt *ImplementsAllTheThings) ListDefinitions(
 	limit int, offset int, sortBy string,


### PR DESCRIPTION
Override `node_lifecycle` type based on the recent history of EKS pod attempts. 

If more than 5% (default) of pods on spot instances are taking more than a single attempt to run successfully to completion, then switch to on-demand nodes. 

The lookback history is set to a default of 3 hours. 