### PR TITLE
Adding spot threshold minutes

### DIFF
--- a/services/execution.go
+++ b/services/execution.go
@@ -263,7 +263,7 @@ func (es *executionService) constructBaseRunFromExecutable(executable state.Exec
 		fields.NodeLifecycle = &state.OndemandLifecycle
 	}
 
-	if taskExecutionMinutes >= float32(es.spotThresholdMinutes) {
+	if taskExecutionMinutes > float32(es.spotThresholdMinutes) {
 		fields.NodeLifecycle = &state.OndemandLifecycle
 	}
 

--- a/services/execution_test.go
+++ b/services/execution_test.go
@@ -38,13 +38,14 @@ func TestExecutionService_CreateDefinitionRunByDefinitionID(t *testing.T) {
 		{Name: "K1", Value: "V1"},
 	}
 	expectedCalls := map[string]bool{
-		"GetDefinition":       true,
-		"IsImageValid":        true,
-		"CanBeRun":            true,
-		"CreateRun":           true,
-		"UpdateRun":           true,
-		"GetPodReAttemptRate": true,
-		"Enqueue":             true,
+		"GetDefinition":            true,
+		"IsImageValid":             true,
+		"CanBeRun":                 true,
+		"CreateRun":                true,
+		"UpdateRun":                true,
+		"GetTaskHistoricalRuntime": true,
+		"GetPodReAttemptRate":      true,
+		"Enqueue":                  true,
 	}
 
 	cmd := "_test_cmd_"
@@ -147,13 +148,14 @@ func TestExecutionService_CreateDefinitionRunByAlias(t *testing.T) {
 		{Name: "K1", Value: "V1"},
 	}
 	expectedCalls := map[string]bool{
-		"GetDefinitionByAlias": true,
-		"IsImageValid":         true,
-		"CanBeRun":             true,
-		"CreateRun":            true,
-		"UpdateRun":            true,
-		"GetPodReAttemptRate":  true,
-		"Enqueue":              true,
+		"GetDefinitionByAlias":     true,
+		"IsImageValid":             true,
+		"CanBeRun":                 true,
+		"CreateRun":                true,
+		"UpdateRun":                true,
+		"GetTaskHistoricalRuntime": true,
+		"GetPodReAttemptRate":      true,
+		"Enqueue":                  true,
 	}
 	mem := int64(1024)
 	engine := state.DefaultEngine

--- a/state/manager.go
+++ b/state/manager.go
@@ -49,6 +49,7 @@ type Manager interface {
 
 	ListFailingNodes() (NodeList, error)
 	GetPodReAttemptRate() (float32, error)
+	GetTaskHistoricalRuntime() (float32, error)
 }
 
 //

--- a/state/pg_state_manager.go
+++ b/state/pg_state_manager.go
@@ -59,6 +59,22 @@ func (sm *SQLStateManager) GetPodReAttemptRate() (float32, error) {
 	return attemptRate, err
 }
 
+func (sm *SQLStateManager) GetTaskHistoricalRuntime() (float32, error) {
+	var err error
+	minutes := float32(1.0)
+	err = sm.db.Get(&minutes, TaskExecutionRuntimeCommandSQL)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return minutes, exceptions.MissingResource{
+				ErrorString: fmt.Sprintf("Error fetching TaskRuntime rate")}
+		} else {
+			return minutes, errors.Wrapf(err, "Error fetching attempt rate")
+		}
+	}
+	return minutes, err
+}
+
 func (sm *SQLStateManager) EstimateRunResources(executableID string, runID string) (TaskResources, error) {
 	var err error
 	var taskResources TaskResources
@@ -592,7 +608,7 @@ func (sm *SQLStateManager) UpdateRun(runID string, updates Run) (Run, error) {
       task_arn = $2, definition_id = $3,
 	  alias = $4, image = $5,
       cluster_name = $6, exit_code = $7,
-      exit_reason = $8, 
+      exit_reason = $8,
       status = $9, queued_at = $10,
       started_at = $11,
       finished_at = $12, instance_id = $13,

--- a/testutils/mocks.go
+++ b/testutils/mocks.go
@@ -78,6 +78,11 @@ func (iatt *ImplementsAllTheThings) GetPodReAttemptRate() (float32, error) {
 	return 1.0, nil
 }
 
+func (iatt *ImplementsAllTheThings) GetTaskHistoricalRuntime() (float32, error){
+	iatt.Calls = append(iatt.Calls, "GetTaskHistoricalRuntime")
+	return 1.0, nil
+}
+
 // ListDefinitions - StateManager
 func (iatt *ImplementsAllTheThings) ListDefinitions(
 	limit int, offset int, sortBy string,


### PR DESCRIPTION
- Look at the historical running time of a particular job. If greater than 30 minutes then don't assign spot
- If current termination of spot instances > 5% in the last 30 minutes, don't assign to spot