### PR TITLE
Manually add newlines at the end of every log line

### DIFF
--- a/ui/src/components/LogProcessor.tsx
+++ b/ui/src/components/LogProcessor.tsx
@@ -79,7 +79,9 @@ export class LogProcessor extends React.Component<Props, State> {
 
   render() {
     const { width, height, hasRunFinished } = this.props
-    const { isProcessing, processedLogs } = this.state
+    let { isProcessing, processedLogs } = this.state
+
+    processedLogs = processedLogs.map((el) => el + "\n")
 
     // If no existing logs and processing, return spinner.
     if (isProcessing && processedLogs.length === 0) {


### PR DESCRIPTION
When copying from a run's logs using the Optimized Log Renderer, the copied text does not include newlines. When multiple log lines are copied and then pasted (e.g. to share a stack trace), the lines all run together.

This PR demonstrates one possible fix for it, but we probably want to handle it in a more sane way. The purpose of this PR is just to demonstrate what needs to change in order to fix the issue.

**NOTE:** This is a very simple proof of concept. This is unlikely to be the actual change that we want to make.