### PR TITLE
updating query for ARA to increase baseline memory for OOM

### DIFF
--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -53,17 +53,18 @@ const GetDefinitionByAliasSQL = DefinitionSelect + "\nwhere alias = $1"
 const TaskResourcesSelectCommandSQL = `
 SELECT cast((percentile_disc(0.99) within GROUP (ORDER BY A.max_memory_used)) * 1.75 as int) as memory,
        cast((percentile_disc(0.99) within GROUP (ORDER BY A.max_cpu_used)) * 1.25  as int)  as cpu
-FROM (SELECT max_memory_used, max_cpu_used
+FROM (SELECT CASE WHEN exit_code = 137 THEN memory * 2 ELSE max_memory_used END as max_memory_used, max_cpu_used
       FROM TASK
       WHERE
            queued_at >= CURRENT_TIMESTAMP - INTERVAL '7 days'
-           AND exit_code = 0
+           AND (exit_code = 0 or exit_code = 137)
            AND max_memory_used is not null
            AND max_cpu_used is not null
            AND engine = 'eks'
            AND definition_id = $1
            AND command_hash = (SELECT command_hash FROM task WHERE run_id = $2)
       LIMIT 30) A
+
 `
 const TaskExecutionRuntimeCommandSQL = `
 SELECT percentile_disc(0.95) within GROUP (ORDER BY A.minutes) as minutes


### PR DESCRIPTION
If a job OOMs out, ARA will increase the specified memory by 2. 