### PR TITLE
skip sending traffic to nodes that may have hit oom

### DIFF
--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -84,6 +84,7 @@ SELECT instance_dns_name
       WHERE (exit_code = 128 OR
             pod_events @> '[{"reason": "Failed"}]' OR
             pod_events @> '[{"reason": "FailedSync"}]' OR
+            pod_events @> '[{"reason": "OutOfmemory"}]' OR
             pod_events @> '[{"reason": "FailedCreatePodSandBox"}]' OR
             (exit_code = 1 AND exit_reason is null))
            AND engine = 'eks'


### PR DESCRIPTION
If a node has a node event around oom, avoid sending further traffic to it.

```
  "pod_events": [
    {
      "timestamp": "2021-01-05T15:36:41.046816989Z",
      "event_type": "Warning",
      "reason": "OutOfmemory",
      "source_object": "eks-c498-6a13-4357-5add-bd805de9a3d4-s5r42",
      "message": "Node didn't have enough resource: memory, requested: 1024000000, used: 25970864000, capacity: 26433814528"
    },
    ...
```