### PR TITLE
parse pod name from kubernetes events

### DIFF
--- a/execution/engine/eks_engine.go
+++ b/execution/engine/eks_engine.go
@@ -221,7 +221,7 @@ func (ee *EKSExecutionEngine) getPodList(run state.Run) (*v1.PodList, error) {
 			return &v1.PodList{Items: []v1.Pod{*pod}}, err
 		}
 	} else {
-		if run.QueuedAt.Before(time.Now().Add(time.Minute * time.Duration(5))) {
+		if time.Now().After(run.QueuedAt.Add(time.Minute * time.Duration(5))) {
 			podList, err := kClient.CoreV1().Pods(ee.jobNamespace).List(metav1.ListOptions{
 				LabelSelector: fmt.Sprintf("job-name=%s", run.RunID),
 			})


### PR DESCRIPTION
- remove the fetching of list pods (only do it if no pod name has been associated to a job in over 5 mins)
- use kubernetes scheduled events to associate a pod name