### PR TITLE
ActiveDeadlineSeconds for task runs

### DIFF
--- a/.migrations/V20210427125201__add_active_deadline_seconds.sql
+++ b/.migrations/V20210427125201__add_active_deadline_seconds.sql
@@ -1,0 +1,1 @@
+ALTER TABLE task ADD COLUMN active_deadline_seconds integer;

--- a/execution/adapter/eks_adapter.go
+++ b/execution/adapter/eks_adapter.go
@@ -122,7 +122,6 @@ func (a *eksAdapter) AdaptFlotillaDefinitionAndRunToJob(executable state.Executa
 	annotations := map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"}
 
 	if run.ActiveDeadlineSeconds == nil {
-
 		if *run.NodeLifecycle == state.OndemandLifecycle {
 			run.ActiveDeadlineSeconds = &state.OndemandActiveDeadlineSeconds
 		} else {

--- a/state/models.go
+++ b/state/models.go
@@ -451,6 +451,7 @@ type Run struct {
 	AttemptCount            *int64                   `json:"attempt_count,omitempty"`
 	SpawnedRuns             *SpawnedRuns             `json:"spawned_runs,omitempty"`
 	RunExceptions           *RunExceptions           `json:"run_exceptions,omitempty"`
+	ActiveDeadlineSeconds   *int64                   `json:"active_deadline_seconds,omitempty"`
 }
 
 //

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -160,7 +160,8 @@ select
   memory_limit as memorylimit,
   attempt_count as attemptcount,
   spawned_runs::TEXT as spawnedruns,
-  run_exceptions::TEXT as runexceptions
+  run_exceptions::TEXT as runexceptions,
+  active_deadline_seconds as activedeadlineseconds
 from task t
 `
 

--- a/state/pg_state_manager.go
+++ b/state/pg_state_manager.go
@@ -606,7 +606,7 @@ func (sm *SQLStateManager) UpdateRun(runID string, updates Run) (Run, error) {
 			&existing.Cpu, &existing.Gpu, &existing.Engine, &existing.EphemeralStorage, &existing.NodeLifecycle,
 			&existing.ContainerName, &existing.PodName, &existing.Namespace, &existing.MaxCpuUsed, &existing.MaxMemoryUsed,
 			&existing.PodEvents, &existing.CommandHash, &existing.CloudTrailNotifications, &existing.ExecutableID,
-			&existing.ExecutableType, &existing.ExecutionRequestCustom, &existing.CpuLimit, &existing.MemoryLimit, &existing.AttemptCount, &existing.SpawnedRuns, &existing.RunExceptions)
+			&existing.ExecutableType, &existing.ExecutionRequestCustom, &existing.CpuLimit, &existing.MemoryLimit, &existing.AttemptCount, &existing.SpawnedRuns, &existing.RunExceptions, &existing.ActiveDeadlineSeconds)
 	}
 	if err != nil {
 		return existing, errors.WithStack(err)
@@ -628,7 +628,7 @@ func (sm *SQLStateManager) UpdateRun(runID string, updates Run) (Run, error) {
 	  command = $17, memory = $18, cpu = $19, gpu = $20, engine = $21, ephemeral_storage = $22, node_lifecycle = $23,
 	  container_name = $24, pod_name = $25, namespace = $26, max_cpu_used = $27, max_memory_used = $28, pod_events = $29,
 	  cloudtrail_notifications = $30, executable_id = $31, executable_type = $32, execution_request_custom = $33,
-	  cpu_limit = $34, memory_limit = $35, attempt_count = $36, spawned_runs = $37, run_exceptions = $38
+	  cpu_limit = $34, memory_limit = $35, attempt_count = $36, spawned_runs = $37, run_exceptions = $38, active_deadline_seconds = $39
     WHERE run_id = $1;
     `
 
@@ -647,7 +647,7 @@ func (sm *SQLStateManager) UpdateRun(runID string, updates Run) (Run, error) {
 		existing.ContainerName, existing.PodName, existing.Namespace, existing.MaxCpuUsed,
 		existing.MaxMemoryUsed, existing.PodEvents, existing.CloudTrailNotifications,
 		existing.ExecutableID, existing.ExecutableType, existing.ExecutionRequestCustom,
-		existing.CpuLimit, existing.MemoryLimit, existing.AttemptCount, existing.SpawnedRuns, existing.RunExceptions); err != nil {
+		existing.CpuLimit, existing.MemoryLimit, existing.AttemptCount, existing.SpawnedRuns, existing.RunExceptions, existing.ActiveDeadlineSeconds); err != nil {
 		tx.Rollback()
 		return existing, errors.WithStack(err)
 	}
@@ -672,10 +672,10 @@ func (sm *SQLStateManager) CreateRun(r Run) error {
       queued_at, started_at, finished_at, instance_id, instance_dns_name, group_name,
       env, task_type, command, memory, cpu, gpu, engine, node_lifecycle, ephemeral_storage,
 			container_name, pod_name, namespace, max_cpu_used, max_memory_used, pod_events, command_hash,
-			executable_id, executable_type, execution_request_custom, cpu_limit, memory_limit, attempt_count, spawned_runs, run_exceptions
+			executable_id, executable_type, execution_request_custom, cpu_limit, memory_limit, attempt_count, spawned_runs, run_exceptions, active_deadline_seconds
     ) VALUES (
       $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, 'task', $17, $18, $19, $20, $21, $22, $23,
-      $24, $25, $26, $27, $28, $29, MD5($17), $30, $31, $32, $33, $34, $35, $36, $37);
+      $24, $25, $26, $27, $28, $29, MD5($17), $30, $31, $32, $33, $34, $35, $36, $37, $38);
     `
 
 	tx, err := sm.db.Begin()
@@ -692,7 +692,7 @@ func (sm *SQLStateManager) CreateRun(r Run) error {
 		r.Env, r.Command, r.Memory, r.Cpu, r.Gpu, r.Engine, r.NodeLifecycle,
 		r.EphemeralStorage, r.ContainerName, r.PodName, r.Namespace, r.MaxCpuUsed,
 		r.MaxMemoryUsed, r.PodEvents, r.ExecutableID, r.ExecutableType,
-		r.ExecutionRequestCustom, r.CpuLimit, r.MemoryLimit, r.AttemptCount, r.SpawnedRuns, r.RunExceptions); err != nil {
+		r.ExecutionRequestCustom, r.CpuLimit, r.MemoryLimit, r.AttemptCount, r.SpawnedRuns, r.RunExceptions, r.ActiveDeadlineSeconds); err != nil {
 		tx.Rollback()
 		return errors.Wrapf(err, "issue creating new task run with id [%s]", r.RunID)
 	}


### PR DESCRIPTION
adding ActiveDeadlineSeconds aka timeout for flotilla runs, if not specified default is used. Specifies the duration in seconds relative to the startTime that the job may be before the system tries to terminate it