### PR TITLE
override emr/eks jobs if spot kills are high

### DIFF
--- a/services/execution.go
+++ b/services/execution.go
@@ -257,6 +257,10 @@ func (es *executionService) constructBaseRunFromExecutable(executable state.Exec
 			return run, errors.New("spark_extension can't be nil, when using eks-spark engine type")
 		}
 		fields.SparkExtension = req.GetExecutionRequestCommon().SparkExtension
+		reAttemptRate, _ := es.stateManager.GetPodReAttemptRate()
+		if reAttemptRate >= es.spotReAttemptOverride {
+			fields.NodeLifecycle = &state.OndemandLifecycle
+		}
 	}
 
 	if fields.NodeLifecycle == nil {


### PR DESCRIPTION
if more than 5% of jobs are reattempted due to pod kills then assign job to ondemand.