### PR TITLE
Adding more visibility for spark driver/executor oom

### DIFF
--- a/state/models.go
+++ b/state/models.go
@@ -199,6 +199,8 @@ type SparkExtension struct {
 	DriverInitCommand    *string               `json:"driver_init_command,omitempty"`
 	AppUri               *string               `json:"app_uri,omitempty"`
 	Executors            []string              `json:"executors,omitempty"`
+	ExecutorOOM          *bool                 `json:"executor_oom,omitempty"`
+	DriverOOM            *bool                 `json:"driver_oom,omitempty"`
 }
 
 type Conf struct {


### PR DESCRIPTION
Check pod statuses for events for the spark job. Store boolean for the executor and/or driver OOM. And upon exit associate the exit code and exit reason. 