### PR TITLE
Adding soft scheduling constraint to set PodAffinity to an AZ

### DIFF
--- a/execution/engine/emr_engine.go
+++ b/execution/engine/emr_engine.go
@@ -423,6 +423,16 @@ func (emr *EMRExecutionEngine) constructAffinity(executable state.Executable, ru
 					TopologyKey: "kubernetes.io/hostname",
 				},
 			},
+				{
+					Weight: 40,
+					PodAffinityTerm: v1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"flotilla-run-id": run.RunID},
+						},
+						TopologyKey: "topology.kubernetes.io/zone",
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
To ensure that pods for a given job stay within an AZ.