### PR TITLE
Adding check for idempotence key when present

### DIFF
--- a/.migrations/V20220907125201__add_idempotence.sql
+++ b/.migrations/V20220907125201__add_idempotence.sql
@@ -1,0 +1,1 @@
+ALTER TABLE task ADD COLUMN IF NOT EXISTS idempotence_key varchar;

--- a/flotilla/endpoints.go
+++ b/flotilla/endpoints.go
@@ -54,6 +54,7 @@ type LaunchRequestV2 struct {
 	Env                   *state.EnvList        `json:"env,omitempty"`
 	Description           *string               `json:"description,omitempty"`
 	CommandHash           *string               `json:"command_hash,omitempty"`
+	IdempotenceKey        *string               `json:"idempotence_key,omitempty"`
 }
 
 //
@@ -485,6 +486,7 @@ func (ep *endpoints) CreateRunV2(w http.ResponseWriter, r *http.Request) {
 			SparkExtension:   lr.SparkExtension,
 			Description:      lr.Description,
 			CommandHash:      lr.CommandHash,
+			IdempotenceKey:   lr.IdempotenceKey,
 		},
 	}
 	run, err := ep.executionService.CreateDefinitionRunByDefinitionID(vars["definition_id"], &req)
@@ -551,6 +553,7 @@ func (ep *endpoints) CreateRunV4(w http.ResponseWriter, r *http.Request) {
 			SparkExtension:        lr.SparkExtension,
 			Description:           lr.Description,
 			CommandHash:           lr.CommandHash,
+			IdempotenceKey:        lr.IdempotenceKey,
 		},
 	}
 
@@ -618,6 +621,7 @@ func (ep *endpoints) CreateRunByAlias(w http.ResponseWriter, r *http.Request) {
 			SparkExtension:        lr.SparkExtension,
 			Description:           lr.Description,
 			CommandHash:           lr.CommandHash,
+			IdempotenceKey:        lr.IdempotenceKey,
 		},
 	}
 	run, err := ep.executionService.CreateDefinitionRunByAlias(vars["alias"], &req)

--- a/services/execution.go
+++ b/services/execution.go
@@ -519,7 +519,7 @@ func (es *executionService) createAndEnqueueRun(run state.Run) (state.Run, error
 		priorRunId, err := es.stateManager.CheckIdempotenceKey(*run.IdempotenceKey)
 		if err == nil && len(priorRunId) > 0 {
 			priorRun, err := es.Get(priorRunId)
-			if err != nil {
+			if err == nil {
 				return priorRun, nil
 			}
 		}

--- a/services/execution_test.go
+++ b/services/execution_test.go
@@ -60,6 +60,7 @@ func TestExecutionService_CreateDefinitionRunByDefinitionID(t *testing.T) {
 			Engine:           &engine,
 			EphemeralStorage: nil,
 			NodeLifecycle:    nil,
+			IdempotenceKey:   nil,
 		},
 	}
 	run, err := es.CreateDefinitionRunByDefinitionID("B", &req)
@@ -162,6 +163,7 @@ func TestExecutionService_CreateDefinitionRunByAlias(t *testing.T) {
 			Engine:           &engine,
 			EphemeralStorage: nil,
 			NodeLifecycle:    nil,
+			IdempotenceKey:   nil,
 		},
 	}
 	run, err := es.CreateDefinitionRunByAlias("aliasB", &req)

--- a/state/manager.go
+++ b/state/manager.go
@@ -54,6 +54,7 @@ type Manager interface {
 	GetPodReAttemptRate() (float32, error)
 	GetNodeLifecycle(executableID string, commandHash string) (string, error)
 	GetTaskHistoricalRuntime(executableID string, runId string) (float32, error)
+	CheckIdempotenceKey(idempotenceKey string) (string, error)
 
 	GetRunByEMRJobId(string) (Run, error)
 }

--- a/state/models.go
+++ b/state/models.go
@@ -237,6 +237,7 @@ type ExecutionRequestCommon struct {
 	SparkExtension        *SparkExtension `json:"spark_extension,omitempty"`
 	Description           *string         `json:"description,omitempty"`
 	CommandHash           *string         `json:"command_hash,omitempty"`
+	IdempotenceKey        *string         `json:"idempotence_key,omitempty"`
 }
 
 type ExecutionRequestCustom map[string]interface{}
@@ -482,6 +483,7 @@ type Run struct {
 	SparkExtension          *SparkExtension          `json:"spark_extension,omitempty"`
 	MetricsUri              *string                  `json:"metrics_uri,omitempty"`
 	Description             *string                  `json:"description,omitempty"`
+	IdempotenceKey          *string                  `json:"idempotence_key,omitempty"`
 }
 
 //
@@ -628,6 +630,10 @@ func (d *Run) UpdateWith(other Run) {
 
 	if other.Description != nil {
 		d.Description = other.Description
+	}
+
+	if other.IdempotenceKey != nil {
+		d.IdempotenceKey = other.IdempotenceKey
 	}
 
 	if other.MemoryLimit != nil {

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -76,6 +76,14 @@ WHERE queued_at >= CURRENT_TIMESTAMP - INTERVAL '7 days'
 GROUP BY 1
 `
 
+const TaskIdempotenceKeyCheckSQL = `
+SELECT run_id
+FROM task
+WHERE idempotence_key = $1 and (exit_code = 0 || exit_code is nil)
+ORDER BY queued_at desc
+LIMIT 1
+`
+
 const TaskResourcesExecutorOOMSQL = `
 SELECT CASE WHEN A.c >= 1 THEN true::boolean ELSE false::boolean END
 FROM (SELECT count(*) as c

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -195,7 +195,8 @@ select t.run_id                          as runid,
        active_deadline_seconds           as activedeadlineseconds,
        spark_extension::TEXT             as sparkextension,
        metrics_uri                       as metricsuri,
-       description                       as description
+       description                       as description,
+	   idempotence_key                   as idempotencekey
 from task t
 `
 

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -79,7 +79,7 @@ GROUP BY 1
 const TaskIdempotenceKeyCheckSQL = `
 SELECT run_id
 FROM task
-WHERE idempotence_key = $1 and (exit_code = 0 || exit_code is nil)
+WHERE idempotence_key = $1 and (exit_code = 0 || exit_code is null)
 ORDER BY queued_at desc
 LIMIT 1
 `

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -79,7 +79,7 @@ GROUP BY 1
 const TaskIdempotenceKeyCheckSQL = `
 SELECT run_id
 FROM task
-WHERE idempotence_key = $1 and (exit_code = 0 || exit_code is null)
+WHERE idempotence_key = $1 and (exit_code = 0 or exit_code is null) and queued_at >= CURRENT_TIMESTAMP - INTERVAL '7 days'
 ORDER BY queued_at desc
 LIMIT 1
 `

--- a/state/pg_state_manager.go
+++ b/state/pg_state_manager.go
@@ -811,7 +811,7 @@ func (sm *SQLStateManager) UpdateRun(runID string, updates Run) (Run, error) {
 		spark_extension = $38,
 		metrics_uri = $39,
 		description = $40,
-		idempotence_key = $41,
+		idempotence_key = $41
     WHERE run_id = $1;
     `
 

--- a/state/pg_state_manager.go
+++ b/state/pg_state_manager.go
@@ -131,13 +131,13 @@ func (sm *SQLStateManager) EstimateExecutorCount(executableID string, commandHas
 }
 func (sm *SQLStateManager) CheckIdempotenceKey(idempotenceKey string) (string, error) {
 	var err error
-	var runId *string
-	err = sm.readonlyDB.Get(runId, TaskIdempotenceKeyCheckSQL, idempotenceKey)
+	runId := ""
+	err = sm.readonlyDB.Get(&runId, TaskIdempotenceKeyCheckSQL, idempotenceKey)
 
-	if runId == nil || err != nil {
+	if err != nil || len(runId) == 0 {
 		err = errors.New("no run_id found for idempotence key")
 	}
-	return *runId, err
+	return runId, err
 }
 
 func (sm *SQLStateManager) ExecutorOOM(executableID string, commandHash string) (bool, error) {

--- a/state/pg_state_manager_test.go
+++ b/state/pg_state_manager_test.go
@@ -612,7 +612,11 @@ func TestSQLStateManager_UpdateRun(t *testing.T) {
 		t.Errorf("Error while updating %v", e)
 	}
 
-	r, _ := sm.GetRun("run3")
+	r, e := sm.GetRun("run3")
+
+	if e != nil {
+		t.Errorf("Error in GetRun %v", e)
+	}
 	if *r.ExitCode != ec {
 		t.Errorf("Expected update to set exit code to %v but was %v", ec, *r.ExitCode)
 	}

--- a/state/pg_state_manager_test.go
+++ b/state/pg_state_manager_test.go
@@ -607,7 +607,10 @@ func TestSQLStateManager_UpdateRun(t *testing.T) {
 	u2 := Run{
 		Status: StatusNeedsRetry,
 	}
-	sm.UpdateRun("run3", u)
+	_, e := sm.UpdateRun("run3", u)
+	if e != nil {
+		t.Errorf("Error while updating %v", e)
+	}
 
 	r, _ := sm.GetRun("run3")
 	if *r.ExitCode != ec {

--- a/testutils/mocks.go
+++ b/testutils/mocks.go
@@ -239,7 +239,7 @@ func (iatt *ImplementsAllTheThings) ListWorkers(engine string) (state.WorkersLis
 
 func (iatt *ImplementsAllTheThings) CheckIdempotenceKey(idempotenceKey string) (string, error) {
 	iatt.Calls = append(iatt.Calls, "CheckIdempotenceKey")
-	return idempotenceKey, nil
+	return "42", nil
 }
 
 // GetWorker - StateManager

--- a/testutils/mocks.go
+++ b/testutils/mocks.go
@@ -237,6 +237,11 @@ func (iatt *ImplementsAllTheThings) ListWorkers(engine string) (state.WorkersLis
 	return state.WorkersList{Total: len(iatt.Workers), Workers: iatt.Workers}, nil
 }
 
+func (iatt *ImplementsAllTheThings) CheckIdempotenceKey(idempotenceKey string) (string, error) {
+	iatt.Calls = append(iatt.Calls, "CheckIdempotenceKey")
+	return idempotenceKey, nil
+}
+
 // GetWorker - StateManager
 func (iatt *ImplementsAllTheThings) GetWorker(workerType string, engine string) (state.Worker, error) {
 	iatt.Calls = append(iatt.Calls, "GetWorker")


### PR DESCRIPTION
Prevents duplicate runs created for the same thumbprint or idempotence key.