### PR TITLE
Adding sidecar containers and additional resource env vars

### DIFF
--- a/worker/status_worker.go
+++ b/worker/status_worker.go
@@ -272,16 +272,6 @@ func (sw *statusWorker) extractExceptions(runID string) {
 	}
 }
 
-func (sw *statusWorker) processEKSRunMetrics(run state.Run) {
-	updatedRun, err := sw.ee.FetchPodMetrics(run)
-	if err == nil {
-		if updatedRun.MaxMemoryUsed != run.MaxMemoryUsed ||
-			updatedRun.MaxCpuUsed != run.MaxCpuUsed {
-			_, err = sw.sm.UpdateRun(updatedRun.RunID, updatedRun)
-		}
-	}
-}
-
 func (sw *statusWorker) logStatusUpdate(update state.Run) {
 	var err error
 	var startedAt, finishedAt time.Time


### PR DESCRIPTION
This PR introduces sidecar running for both EMR and non-EMR jobs. The command slice running in the sidecars is shared between containers; a good use case is to measure job heartbeat/aliveness/logging.

Added the following configuration variables.

```
eks_sidecar_command
emr_sidecar_command
emr_sidecar_image
```

