### PR TITLE
Update utils.go

### DIFF
--- a/execution/utils.go
+++ b/execution/utils.go
@@ -33,6 +33,13 @@ func SanitizeLabel(key string) string {
 	if len(key) > 63 {
 		key = key[:63]
 	}
-	key = strings.TrimSuffix(key, "_")
+    	for {
+        	tempKey = strings.TrimSuffix(key, "_")
+		if tempKey == key {
+		    break
+		}
+		key = tempKey
+    	}
+
 	return key
 }

--- a/execution/utils.go
+++ b/execution/utils.go
@@ -33,5 +33,6 @@ func SanitizeLabel(key string) string {
 	if len(key) > 63 {
 		key = key[:63]
 	}
+	key = strings.TrimSuffix(key, "_")
 	return key
 }

--- a/execution/utils.go
+++ b/execution/utils.go
@@ -34,7 +34,7 @@ func SanitizeLabel(key string) string {
 		key = key[:63]
 	}
     	for {
-        	tempKey = strings.TrimSuffix(key, "_")
+        	tempKey := strings.TrimSuffix(key, "_")
 		if tempKey == key {
 		    break
 		}

--- a/execution/utils_test.go
+++ b/execution/utils_test.go
@@ -49,6 +49,12 @@ func TestSanitizeLabel(t *testing.T) {
 			input:    "a_",
 			expected: "a",
 		},
+		{
+			name:     "removes repeated trailing _'s",
+			input:    "a_____",
+			expected: "a",
+		},
+
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/execution/utils_test.go
+++ b/execution/utils_test.go
@@ -31,8 +31,8 @@ func TestSanitizeLabel(t *testing.T) {
 		},
 		{
 			name:     "replaces special chars",
-			input:    "a*",
-			expected: "a_",
+			input:    "a*s",
+			expected: "a_s",
 		},
 		{
 			name:     "trims spaces",
@@ -42,6 +42,11 @@ func TestSanitizeLabel(t *testing.T) {
 		{
 			name:     "removes leading _'s",
 			input:    "_a",
+			expected: "a",
+		},
+		{
+			name:     "removes trailing _'s",
+			input:    "a_",
 			expected: "a",
 		},
 	}


### PR DESCRIPTION
Trailing `_`s [aren't valid](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set) for k8s labels