### PR TITLE
Reduce ARA MaxMem

### DIFF
--- a/state/models.go
+++ b/state/models.go
@@ -32,7 +32,7 @@ var MaxCPU = int64(128000)
 
 var MinMem = int64(512)
 
-var MaxMem = int64(500000)
+var MaxMem = int64(350000)
 
 var TTLSecondsAfterFinished = int32(3600)
 


### PR DESCRIPTION
We don't have instance types with 500GB of memory (outside of GPU instances).