### PR TITLE
Fix for reading newer Spark log files.

### DIFF
--- a/clients/logs/eks_s3_logs_client.go
+++ b/clients/logs/eks_s3_logs_client.go
@@ -3,6 +3,7 @@ package logs
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
@@ -144,16 +145,26 @@ func (lc *EKSS3LogsClient) emrLogsToMessageString(run state.Run, lastSeen *strin
 		}
 	}
 
-	s3Obj, err := lc.s3Client.GetObject(&s3.GetObjectInput{
-		Bucket: aws.String(lc.emrS3LogsBucket),
-		Key:    aws.String(*key),
-	})
+	s3Obj, err := s3Client.GetObjectWithContext(
+		context.Background(),
+		&s3.GetObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		}, func(r *request.Request) {
+			// Otherwise we get an unzipped response.
+			r.HTTPRequest.Header.Add("Accept-Encoding", "gzip")
+		})
 
-	if s3Obj != nil && err == nil && *s3Obj.ContentLength < int64(10000000) {
+	if s3Obj != nil && err == nil {
+
+		if s3Obj.ContentLength != nil && *s3Obj.ContentLength > int64(10000000) {
+			return "", aws.String(""), errors.Errorf("Logs > 10MB, will not display.")
+		}
+
 		defer s3Obj.Body.Close()
 		gr, err := gzip.NewReader(s3Obj.Body)
 		if err != nil {
-			return "", aws.String(""), errors.Errorf("No driver logs found")
+			return "", aws.String(""), err
 		}
 		defer gr.Close()
 		reader := bufio.NewReader(gr)

--- a/clients/logs/eks_s3_logs_client.go
+++ b/clients/logs/eks_s3_logs_client.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pkg/errors"

--- a/clients/logs/eks_s3_logs_client.go
+++ b/clients/logs/eks_s3_logs_client.go
@@ -145,11 +145,11 @@ func (lc *EKSS3LogsClient) emrLogsToMessageString(run state.Run, lastSeen *strin
 		}
 	}
 
-	s3Obj, err := s3Client.GetObjectWithContext(
+	s3Obj, err := lc.s3Client.GetObjectWithContext(
 		context.Background(),
 		&s3.GetObjectInput{
-			Bucket: aws.String(bucket),
-			Key:    aws.String(key),
+			Bucket: aws.String(lc.emrS3LogsBucket),
+			Key:    aws.String(*key),
 		}, func(r *request.Request) {
 			// Otherwise we get an unzipped response.
 			r.HTTPRequest.Header.Add("Accept-Encoding", "gzip")


### PR DESCRIPTION
As of Spark 3.3/EMR 6.11, the files have different headers.

New:
Content-Encoding	gzip
Content-Type	text/plain

Old:
Content-Type	application/x-gzip

For the new headers, if we don't specify that we can handle gzip, then AWS unzips it for us on the server side.

I also updated some related error cases to yield clearer error messages.