### PR TITLE
Update ImagePullPolicy to always.

### DIFF
--- a/execution/adapter/eks_adapter.go
+++ b/execution/adapter/eks_adapter.go
@@ -109,12 +109,13 @@ func (a *eksAdapter) AdaptFlotillaDefinitionAndRunToJob(executable state.Executa
 	volumeMounts, volumes := a.constructVolumeMounts(executable, run, manager, araEnabled)
 
 	container := corev1.Container{
-		Name:      run.RunID,
-		Image:     run.Image,
-		Command:   cmdSlice,
-		Resources: resourceRequirements,
-		Env:       a.envOverrides(executable, run),
-		Ports:     a.constructContainerPorts(executable),
+		Name:            run.RunID,
+		Image:           run.Image,
+		ImagePullPolicy: corev1.PullAlways,
+		Command:         cmdSlice,
+		Resources:       resourceRequirements,
+		Env:             a.envOverrides(executable, run),
+		Ports:           a.constructContainerPorts(executable),
 	}
 
 	if volumeMounts != nil {


### PR DESCRIPTION
https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
to always get the latest version of the image when using mutable tags.