### PR TITLE
Enables the use of lustre FSx 

### DIFF
--- a/execution/engine/emr_engine.go
+++ b/execution/engine/emr_engine.go
@@ -430,10 +430,15 @@ func (emr *EMRExecutionEngine) deletePVC(run state.Run) error {
 		run.ExitReason = &exitReason
 		return nil
 	}
+	err = kClient.CoreV1().Pods(emr.emrJobNamespace).Delete(fmt.Sprintf("chmod-fsx-pod-%s", run.RunID), &metav1.DeleteOptions{})
+	if err != nil {
+		return emr.log.Log("Error Removing chmod pod", "error", err.Error())
+	}
 	err = kClient.CoreV1().PersistentVolumeClaims(emr.emrJobNamespace).Delete(pvcName, &metav1.DeleteOptions{})
 	if err != nil {
 		return emr.log.Log("pvc deletion error", "error", err.Error())
 	}
+
 	return nil
 }
 

--- a/execution/engine/emr_engine.go
+++ b/execution/engine/emr_engine.go
@@ -130,7 +130,7 @@ func (emr *EMRExecutionEngine) getKClient(run state.Run) (kubernetes.Clientset, 
 
 func (emr *EMRExecutionEngine) Execute(executable state.Executable, run state.Run, manager state.Manager) (state.Run, bool, error) {
 	// Create PVC before job submission only if not in infra-c
-	if clusterName != "flotilla-eks-infra-c" {
+	if run.ClusterName != "flotilla-eks-infra-c" {
 		err := emr.createPVC(run)
 		if err != nil {
 			return run, false, emr.log.Log("error creating PVC", "error", err.Error())
@@ -225,7 +225,6 @@ func (emr *EMRExecutionEngine) generateApplicationConf(executable state.Executab
 			"spark.kubernetes.driver.reusePersistentVolumeClaim":       aws.String("false"),
 			"spark.kubernetes.driver.waitToReusePersistentVolumeClaim": aws.String("false"),
 
-			"spark.kubernetes.executor.volumes.persistentVolumeClaim.spark-local-dir-shared-lib-volume.options.sizeLimit": aws.String("250Gi"),
 			"spark.kubernetes.executor.volumes.persistentVolumeClaim.spark-local-dir-shared-lib-volume.options.claimName": aws.String(pvcName),
 			"spark.kubernetes.executor.volumes.persistentVolumeClaim.spark-local-dir-shared-lib-volume.mount.path":        aws.String("/var/lib/app/"),
 			"spark.kubernetes.executor.volumes.persistentVolumeClaim.spark-local-dir-shared-lib-volume.mount.readOnly":    aws.String("false"),
@@ -755,7 +754,7 @@ func (emr *EMRExecutionEngine) Terminate(run state.Run) error {
 	}
 	_ = metrics.Increment(metrics.EngineEMRTerminate, []string{string(metrics.StatusSuccess)}, 1)
 
-	if clusterName != "flotilla-eks-infra-c" {
+	if run.ClusterName != "flotilla-eks-infra-c" {
 		err = emr.deletePVC(run)
 		if err != nil {
 			emr.log.Log("error deleting PVC", "error", err.Error())

--- a/execution/engine/emr_engine.go
+++ b/execution/engine/emr_engine.go
@@ -401,7 +401,7 @@ func (emr *EMRExecutionEngine) createPVC(run state.Run) error {
 
 	// Check if PVC is bound
 	isBound := false
-	maxRetries := 100                 // Number of retries before giving up
+	maxRetries := 60                  // Number of retries before giving up
 	retryInterval := 10 * time.Second // Time to wait between retries
 
 	for i := 0; i < maxRetries && !isBound; i++ {


### PR DESCRIPTION
Enables the use of lustre FSx but creates PVC at start of job and removes it at termination

## PROBLEM
Current built in implementation of spark PVC's is it creates a pvc or a volume for each executor. This PR aims to create a lustre mount that is 1 to many that will create a PVC per job and mount it to all executors across multiple nodes. 

## SOLUTION
Handle PVC creation outside of Spark built in methods