### PR TITLE
Disables DD annotations driver and adds a check to see if kube_workflow exists

### DIFF
--- a/execution/engine/emr_engine.go
+++ b/execution/engine/emr_engine.go
@@ -193,11 +193,6 @@ func (emr *EMRExecutionEngine) generateApplicationConf(executable state.Executab
 		"spark.kubernetes.driver.service.annotation.prometheus.io/path":   aws.String("/metrics/driver/prometheus/"),
 		"spark.kubernetes.driver.service.annotation.prometheus.io/scrape": aws.String("true"),
 
-		// Datadog Metrics
-		"spark.kubernetes.driver.annotation.ad.datadoghq.com/spark-kubernetes-driver.check_names":  aws.String("[\"spark\"]"),
-		"spark.kubernetes.driver.annotation.ad.datadoghq.com/spark-kubernetes-driver.init_configs": aws.String("[{}]"),
-		"spark.kubernetes.driver.annotation.ad.datadoghq.com/spark-kubernetes-driver.instances":    utils.SetSparkDatadogConfig(run),
-
 		// Executor-level metrics are sent from each executor to the driver. Prometheus endpoint at: /metrics/executors/prometheus
 		"spark.kubernetes.driver.annotation.prometheus.io/scrape": aws.String("true"),
 		"spark.kubernetes.driver.annotation.prometheus.io/path":   aws.String("/metrics/executors/prometheus/"),

--- a/execution/utils.go
+++ b/execution/utils.go
@@ -21,9 +21,8 @@ func GetLabels(run state.Run) map[string]string {
 		labels["owner"] = SanitizeLabel(run.User)
 	}
 
-	// Forces the workflow name to be the task name if not set this is for manually created tasks
-	if _, exists := run.Labels["kube_workflow"]; !exists {
-		if _, exists := run.Labels["kube_task_name"]; exists {
+	if _, workflowExists := run.Labels["kube_workflow"]; !workflowExists {
+		if _, taskNameExists := run.Labels["kube_task_name"]; taskNameExists {
 			labels["kube_workflow"] = SanitizeLabel(run.Labels["kube_task_name"])
 		}
 	}

--- a/execution/utils.go
+++ b/execution/utils.go
@@ -1,50 +1,10 @@
 package utils
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stitchfix/flotilla-os/state"
-	"log"
 	"regexp"
 	"strings"
 )
-
-// SetSparkDatadogConfig sets the values needed for Spark Datadog integration
-func SetSparkDatadogConfig(run state.Run) *string {
-	var customTags []string
-
-	// Always present tag
-	customTags = append(customTags, fmt.Sprintf("flotilla_run_id:%s", run.RunID))
-
-	// Labels that may or may not exist
-	customTags = append(customTags, getTagOrDefault(run.Labels, "team", "unknown"))
-	customTags = append(customTags, getTagOrDefault(run.Labels, "kube_workflow", "unknown"))
-	customTags = append(customTags, getTagOrDefault(run.Labels, "kube_task_name", "unknown"))
-
-	existingConfig := map[string]interface{}{
-		"spark_url":          "http://%host%:4040",
-		"spark_cluster_mode": "spark_driver_mode",
-		"cluster_name":       run.ClusterName,
-		"tags":               customTags,
-	}
-
-	datadogConfigBytes, err := json.Marshal(existingConfig)
-
-	// We should never reach here as this will always be a valid JSON
-	if err != nil {
-		log.Printf("Failed to marshal existingConfig: %v", err)
-		return nil
-	}
-	return aws.String(string(datadogConfigBytes))
-}
-
-func getTagOrDefault(labels map[string]string, labelName, defaultValue string) string {
-	if value, exists := labels[labelName]; exists && value != "" {
-		return fmt.Sprintf("%s:%s", labelName, value)
-	}
-	return fmt.Sprintf("%s:%s", labelName, defaultValue)
-}
 
 func GetLabels(run state.Run) map[string]string {
 	var labels = make(map[string]string)

--- a/execution/utils.go
+++ b/execution/utils.go
@@ -61,6 +61,10 @@ func GetLabels(run state.Run) map[string]string {
 		labels["owner"] = SanitizeLabel(run.User)
 	}
 
+	if _, exists := run.Labels["kube_workflow"]; !exists {
+		labels["kube_workflow"] = SanitizeLabel(run.Labels["kube_task_name"])
+	}
+
 	for k, v := range run.Labels {
 		labels[k] = SanitizeLabel(v)
 	}

--- a/execution/utils.go
+++ b/execution/utils.go
@@ -21,6 +21,7 @@ func GetLabels(run state.Run) map[string]string {
 		labels["owner"] = SanitizeLabel(run.User)
 	}
 
+	// Forces the workflow name to be the task name if not set this is for manually created tasks
 	if _, exists := run.Labels["kube_workflow"]; !exists {
 		labels["kube_workflow"] = SanitizeLabel(run.Labels["kube_task_name"])
 	}

--- a/execution/utils.go
+++ b/execution/utils.go
@@ -23,7 +23,9 @@ func GetLabels(run state.Run) map[string]string {
 
 	// Forces the workflow name to be the task name if not set this is for manually created tasks
 	if _, exists := run.Labels["kube_workflow"]; !exists {
-		labels["kube_workflow"] = SanitizeLabel(run.Labels["kube_task_name"])
+		if _, exists := run.Labels["kube_task_name"]; exists {
+			labels["kube_workflow"] = SanitizeLabel(run.Labels["kube_task_name"])
+		}
 	}
 
 	for k, v := range run.Labels {

--- a/execution/utils_test.go
+++ b/execution/utils_test.go
@@ -102,7 +102,7 @@ func TestGetLabels(t *testing.T) {
 				"kube_foo":        "bar",
 				"kube_task_name":  "foo",
 				"team":            "awesomeness",
-				"owner":           "userA",
+				"owner":           "usera",
 			},
 		},
 		{

--- a/execution/utils_test.go
+++ b/execution/utils_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"encoding/json"
 	"github.com/stitchfix/flotilla-os/state"
 	"reflect"
 	"strings"
@@ -88,6 +87,7 @@ func TestGetLabels(t *testing.T) {
 					ClusterName:  "A",
 					GroupName:    "groupA",
 					RunID:        "runA",
+					User:         "userA",
 					Labels: map[string]string{
 						"kube_foo":       "bar",
 						"team":           "awesomeness",
@@ -100,7 +100,9 @@ func TestGetLabels(t *testing.T) {
 				"flotilla-run-id": "runa",
 				"kube_workflow":   "foo",
 				"kube_foo":        "bar",
+				"kube_task_name":  "foo",
 				"team":            "awesomeness",
+				"owner":           "usera",
 			},
 		},
 		{
@@ -118,55 +120,5 @@ func TestGetLabels(t *testing.T) {
 				t.Errorf("GetLabels() = %v, want %v", got, tt.want)
 			}
 		})
-	}
-}
-
-// TestSetSparkDatadogConfig tests the SetSparkDatadogConfig function
-func TestSetSparkDatadogConfig(t *testing.T) {
-	// Define a test run object
-	run := state.Run{
-		RunID: "test-run-id",
-		Labels: map[string]string{
-			"team":           "test",
-			"kube_workflow":  "test-workflow",
-			"kube_task_name": "test-task",
-		},
-		ClusterName: "test-cluster",
-	}
-
-	// Expected tags in the JSON output
-	expectedTags := []string{
-		"flotilla_run_id:test-run-id",
-		"team:test",
-		"kube_workflow:test-workflow",
-		"kube_task_name:test-task",
-	}
-
-	// Call the function under test
-	result := SetSparkDatadogConfig(run)
-
-	// Unmarshal the result into a map for easy inspection
-	var resultMap map[string]interface{}
-	err := json.Unmarshal([]byte(*result), &resultMap)
-	if err != nil {
-		t.Fatalf("Failed to unmarshal JSON result: %v", err)
-	}
-
-	// Check each expected tag
-	tags, ok := resultMap["tags"].([]interface{})
-	if !ok {
-		t.Fatalf("Tags are not in the expected format or missing")
-	}
-	for _, expectedTag := range expectedTags {
-		found := false
-		for _, tag := range tags {
-			if tag == expectedTag {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("Expected tag %s not found in result", expectedTag)
-		}
 	}
 }

--- a/execution/utils_test.go
+++ b/execution/utils_test.go
@@ -84,14 +84,21 @@ func TestGetLabels(t *testing.T) {
 			name: "should return labels for run with definition",
 			args: args{
 				run: state.Run{
-					DefinitionID: "A", ClusterName: "A", GroupName: "groupA", RunID: "runA", Labels: map[string]string{
-						"kube_foo": "bar", "team": "awesomeness",
+					DefinitionID: "A",
+					ClusterName:  "A",
+					GroupName:    "groupA",
+					RunID:        "runA",
+					Labels: map[string]string{
+						"kube_foo":       "bar",
+						"team":           "awesomeness",
+						"kube_task_name": "foo",
 					},
 				},
 			},
 			want: map[string]string{
 				"cluster-name":    "A",
 				"flotilla-run-id": "runa",
+				"kube_workflow":   "foo",
 				"kube_foo":        "bar",
 				"team":            "awesomeness",
 			},

--- a/execution/utils_test.go
+++ b/execution/utils_test.go
@@ -102,7 +102,7 @@ func TestGetLabels(t *testing.T) {
 				"kube_foo":        "bar",
 				"kube_task_name":  "foo",
 				"team":            "awesomeness",
-				"owner":           "usera",
+				"owner":           "userA",
 			},
 		},
 		{


### PR DESCRIPTION
## PROBLEM
We are setting annotations via kyverno now. This code is unused. We are getting a issues with adhoc runs of tasks that fail due to not having kube_workflow label set that comes from futura. 

## SOLUTION
Check to see if the label exists and set it to kube_task_name if not present 