### PR TITLE
Force all driver pods to t3a.2xlarge node size

### DIFF
--- a/execution/engine/emr_engine.go
+++ b/execution/engine/emr_engine.go
@@ -334,6 +334,9 @@ func (emr *EMRExecutionEngine) driverPodTemplate(executable state.Executable, ru
 					WorkingDir:   workingDir,
 				},
 			},
+			NodeSelector: map[string]string{
+				"node.kubernetes.io/instance-type": "t3a.2xlarge",
+			},
 			InitContainers: []v1.Container{{
 				Name:         fmt.Sprintf("init-driver-%s", run.RunID),
 				Image:        run.Image,


### PR DESCRIPTION
## PROBLEM
Driver pods take a long time to run but do not require a large amount of resources. Due to this they have been seen as holding up large nodes (c6a.48xlarge) from being released since we cannot interrupt the pods. 

## SOLUTION
This PR sets all Driver pods to be forced to schedule on t3a.2xlarge nodes which should allow us to pack a few driver pods on them and not worry about the cost.