### PR TITLE
Update to the latest version of Go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stitchfix/flotilla-os
 
-go 1.21
+go 1.23.2
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.1.0


### PR DESCRIPTION
# Problem

There is a newer version of Go available.

# Solution

Update `go.mod` to have the latest version in use
          