### PR TITLE
Ensure we are pulling the proper working directory before setting the volume mount

### DIFF
--- a/execution/engine/emr_engine.go
+++ b/execution/engine/emr_engine.go
@@ -310,6 +310,9 @@ func (emr *EMRExecutionEngine) driverPodTemplate(executable state.Executable, ru
 	// Override driver pods to always be on ondemand nodetypes.
 	run.NodeLifecycle = &state.OndemandLifecycle
 	workingDir := "/var/lib/app"
+	if run.SparkExtension != nil && run.SparkExtension.SparkSubmitJobDriver != nil && run.SparkExtension.SparkSubmitJobDriver.WorkingDir != nil {
+		workingDir = *run.SparkExtension.SparkSubmitJobDriver.WorkingDir
+	}
 
 	volumes, volumeMounts := generateVolumesForCluster(run.ClusterName, true)
 
@@ -341,10 +344,6 @@ func (emr *EMRExecutionEngine) driverPodTemplate(executable state.Executable, ru
 		podSpec.NodeSelector = map[string]string{
 			"node.kubernetes.io/instance-type": emr.driverInstanceType,
 		}
-	}
-
-	if run.SparkExtension != nil && run.SparkExtension.SparkSubmitJobDriver != nil && run.SparkExtension.SparkSubmitJobDriver.WorkingDir != nil {
-		workingDir = *run.SparkExtension.SparkSubmitJobDriver.WorkingDir
 	}
 
 	labels := utils.GetLabels(run)


### PR DESCRIPTION
## PROBLEM
https://github.com/stitchfix/flotilla-os/pull/519 Introduced a code change that allowed for drivers to get nodeSelector set via config but workingdir was being set in two places. The new PodSpec that used workingdir is only picking up the default and never setting the settings passed in from spark. 

## SOLUTION
Make sure we are looking at what spark is passing before we set the volume mount