### PR TITLE
Set ImagePullPolicy on container to better support mutable images

### DIFF
--- a/execution/adapter/eks_adapter.go
+++ b/execution/adapter/eks_adapter.go
@@ -107,12 +107,13 @@ func (a *eksAdapter) AdaptFlotillaDefinitionAndRunToJob(executable state.Executa
 	volumeMounts, volumes := a.constructVolumeMounts(executable, run, manager, araEnabled)
 
 	container := corev1.Container{
-		Name:      run.RunID,
-		Image:     run.Image,
-		Command:   cmdSlice,
-		Resources: resourceRequirements,
-		Env:       a.envOverrides(executable, run),
-		Ports:     a.constructContainerPorts(executable),
+		Name:            run.RunID,
+		Image:           run.Image,
+		Command:         cmdSlice,
+		Resources:       resourceRequirements,
+		Env:             a.envOverrides(executable, run),
+		Ports:           a.constructContainerPorts(executable),
+		ImagePullPolicy: corev1.PullAlways,
 	}
 
 	if volumeMounts != nil {


### PR DESCRIPTION
## PROBLEM

Docker images are cached permanently, even though we use mutable tags. This means image changes aren't reflected for a given node until after it is retired.

https://stitchfix.slack.com/archives/CPJNK057A/p1746116414132759
https://stitchfix.slack.com/archives/CPJNK057A/p1744998885332779?thread_ts=1744920814.118329&cid=CPJNK057A

## SOLUTION

Specify `imagePullPolicy: always` to always check the registry.

https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy

> Always
>
> every time the kubelet launches a container, the kubelet queries the container image registry to resolve the name to an image digest. If the kubelet has a container image with that exact digest cached locally, the kubelet uses its cached image; otherwise, the kubelet pulls the image with the resolved digest, and uses that image to launch the container.