### PR TITLE
Add a lightweight endpoint that will allow us to query a run 

### DIFF
--- a/flotilla/endpoints.go
+++ b/flotilla/endpoints.go
@@ -1101,3 +1101,32 @@ func (ep *endpoints) CreateCluster(w http.ResponseWriter, r *http.Request) {
 
 	ep.encodeResponse(w, map[string]bool{"created": true})
 }
+
+func (ep *endpoints) GetRunStatus(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	runID := vars["run_id"]
+
+	status, err := ep.executionService.GetRunStatus(runID)
+	if err != nil {
+		ep.logger.Log(
+			"message", "problem getting run status",
+			"operation", "GetRunStatus",
+			"error", fmt.Sprintf("%+v", err),
+			"run_id", runID)
+		ep.encodeError(w, err)
+		return
+	}
+
+	w.Header().Set("Cache-Control", "max-age=5") // Cache for 5 seconds
+
+	statusHash := fmt.Sprintf("%s-%v", status.Status, status.ExitCode)
+	etag := fmt.Sprintf(`"%s"`, statusHash)
+	w.Header().Set("ETag", etag)
+
+	if match := r.Header.Get("If-None-Match"); match != "" && match == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+
+	ep.encodeResponse(w, status)
+}

--- a/flotilla/endpoints.go
+++ b/flotilla/endpoints.go
@@ -1119,7 +1119,11 @@ func (ep *endpoints) GetRunStatus(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Cache-Control", "max-age=5") // Cache for 5 seconds
 
-	statusHash := fmt.Sprintf("%s-%v", status.Status, status.ExitCode)
+	exitCode := "unknown"
+	if status.ExitCode != nil {
+		exitCode = fmt.Sprintf("%v", *status.ExitCode)
+	}
+	statusHash := fmt.Sprintf("%s-%s", status.Status, exitCode)
 	etag := fmt.Sprintf(`"%s"`, statusHash)
 	w.Header().Set("ETag", etag)
 

--- a/flotilla/router.go
+++ b/flotilla/router.go
@@ -69,6 +69,7 @@ func NewRouter(ep endpoints) *muxtrace.Router {
 	v6.HandleFunc("/task/{definition_id}/history/{run_id}", ep.StopRun).Methods("DELETE")
 	v6.HandleFunc("/task/history/{run_id}", ep.GetRun).Methods("GET")
 	v6.HandleFunc("/{run_id}/status", ep.UpdateRun).Methods("PUT")
+	v6.HandleFunc("/{run_id}/status", ep.GetRunStatus).Methods("GET")
 	v6.HandleFunc("/{run_id}/logs", ep.GetLogs).Methods("GET")
 
 	v7 := r.PathPrefix("/api/v7").Subrouter()

--- a/services/execution.go
+++ b/services/execution.go
@@ -45,6 +45,7 @@ type ExecutionService interface {
 	UpdateClusterMetadata(cluster state.ClusterMetadata) error
 	DeleteClusterMetadata(clusterID string) error
 	GetClusterByID(clusterID string) (state.ClusterMetadata, error)
+	GetRunStatus(runID string) (state.RunStatus, error)
 }
 
 type executionService struct {
@@ -701,4 +702,9 @@ func (es *executionService) DeleteClusterMetadata(clusterID string) error {
 
 func (es *executionService) GetClusterByID(clusterID string) (state.ClusterMetadata, error) {
 	return es.stateManager.GetClusterByID(clusterID)
+}
+
+// GetRunStatus fetches only the essential status information for a run
+func (es *executionService) GetRunStatus(runID string) (state.RunStatus, error) {
+	return es.stateManager.GetRunStatus(runID)
 }

--- a/services/execution_test.go
+++ b/services/execution_test.go
@@ -449,3 +449,54 @@ func TestExecutionService_CreateDefinitionRunWithTier(t *testing.T) {
 		})
 	}
 }
+
+func TestExecutionService_GetRunStatus(t *testing.T) {
+	es, imp := setUp(t)
+
+	expectedCalls := map[string]bool{
+		"GetRunStatus": true,
+	}
+
+	status, err := es.GetRunStatus("runA")
+
+	if err != nil {
+		t.Errorf("Expected no error when getting status of existing run, got: %s", err.Error())
+	}
+
+	if len(imp.Calls) != len(expectedCalls) {
+		t.Errorf("Expected exactly %v calls during status retrieval but was: %v", len(expectedCalls), len(imp.Calls))
+	}
+
+	for _, call := range imp.Calls {
+		_, ok := expectedCalls[call]
+		if !ok {
+			t.Errorf("Unexpected call during status retrieval: %s", call)
+		}
+	}
+
+	if status.RunID != "runA" {
+		t.Errorf("Expected run ID 'runA' but got '%s'", status.RunID)
+	}
+
+	if status.DefinitionID != "A" {
+		t.Errorf("Expected definition ID 'A' but got '%s'", status.DefinitionID)
+	}
+
+	if status.ClusterName != "A" {
+		t.Errorf("Expected cluster name 'A' but got '%s'", status.ClusterName)
+	}
+
+	imp.Calls = []string{}
+
+	_, err = es.GetRunStatus("nonexistent")
+
+	if err == nil {
+		t.Errorf("Expected error when getting status of non-existent run, got nil")
+	}
+
+	expectedErrorString := "No run nonexistent"
+	if err != nil && err.Error() != expectedErrorString {
+		t.Errorf("Expected error message '%s', got '%s'", expectedErrorString, err.Error())
+	}
+
+}

--- a/services/execution_test.go
+++ b/services/execution_test.go
@@ -494,7 +494,7 @@ func TestExecutionService_GetRunStatus(t *testing.T) {
 		t.Errorf("Expected error when getting status of non-existent run, got nil")
 	}
 
-	expectedErrorString := "No run nonexistent"
+	expectedErrorString := "No run with ID: nonexistent"
 	if err != nil && err.Error() != expectedErrorString {
 		t.Errorf("Expected error message '%s', got '%s'", expectedErrorString, err.Error())
 	}

--- a/state/manager.go
+++ b/state/manager.go
@@ -60,6 +60,7 @@ type Manager interface {
 	UpdateClusterMetadata(cluster ClusterMetadata) error
 	DeleteClusterMetadata(clusterID string) error
 	GetClusterByID(clusterID string) (ClusterMetadata, error)
+	GetRunStatus(runID string) (RunStatus, error)
 }
 
 // NewStateManager sets up and configures a new statemanager

--- a/state/models.go
+++ b/state/models.go
@@ -703,6 +703,20 @@ func removeDuplicateStr(strSlice []string) []string {
 
 type byExecutorName []string
 
+type RunStatus struct {
+	RunID        string     `json:"run_id"`
+	Status       string     `json:"status"`
+	QueuedAt     *time.Time `json:"queued_at,omitempty"`
+	StartedAt    *time.Time `json:"started_at,omitempty"`
+	FinishedAt   *time.Time `json:"finished_at,omitempty"`
+	ExitCode     *int64     `json:"exit_code,omitempty"`
+	ExitReason   *string    `json:"exit_reason,omitempty"`
+	Engine       *string    `json:"engine,omitempty"`
+	DefinitionID string     `json:"definition_id"`
+	Alias        string     `json:"alias"`
+	ClusterName  string     `json:"cluster_name"`
+}
+
 func (s byExecutorName) Len() int {
 	return len(s)
 }

--- a/state/pg_queries.go
+++ b/state/pg_queries.go
@@ -223,6 +223,22 @@ select t.run_id                          as runid,
      coalesce(tier::text, 'Tier4')   as tier
 from task t
 `
+const GetRunStatusSQL = `
+SELECT 
+    run_id, 
+    definition_id,
+    alias,
+    cluster_name,
+    status, 
+    queued_at, 
+    started_at, 
+    finished_at, 
+    exit_code, 
+    exit_reason,
+    engine
+FROM task
+WHERE run_id = $1
+`
 
 // ListRunsSQL postgres specific query for listing runs
 const ListRunsSQL = RunSelect + "\n%s %s limit $1 offset $2"

--- a/state/pg_state_manager.go
+++ b/state/pg_state_manager.go
@@ -1932,21 +1932,15 @@ func (arr Capabilities) Value() (driver.Value, error) {
 
 func (sm *SQLStateManager) GetRunStatus(runID string) (RunStatus, error) {
 	var status RunStatus
-
-	// Use a transaction with a short timeout to avoid blocking
 	tx, err := sm.db.Begin()
 	if err != nil {
 		return status, errors.Wrap(err, "failed to begin transaction")
 	}
-
-	// Set a short timeout for this query
 	_, err = tx.Exec("SET LOCAL lock_timeout = '500ms'")
 	if err != nil {
 		tx.Rollback()
 		return status, errors.Wrap(err, "failed to set lock timeout")
 	}
-
-	// Execute the query
 	err = tx.QueryRow(GetRunStatusSQL, runID).Scan(
 		&status.RunID,
 		&status.DefinitionID,
@@ -1960,7 +1954,6 @@ func (sm *SQLStateManager) GetRunStatus(runID string) (RunStatus, error) {
 		&status.ExitReason,
 		&status.Engine,
 	)
-
 	if err != nil {
 		tx.Rollback()
 
@@ -1977,7 +1970,6 @@ func (sm *SQLStateManager) GetRunStatus(runID string) (RunStatus, error) {
 		return status, errors.Wrapf(err, "issue getting run status with id [%s]", runID)
 	}
 
-	// Commit the transaction
 	err = tx.Commit()
 	if err != nil {
 		return status, errors.Wrap(err, "failed to commit transaction")

--- a/state/pg_state_manager.go
+++ b/state/pg_state_manager.go
@@ -1929,3 +1929,59 @@ func (arr Capabilities) Value() (driver.Value, error) {
 	}
 	return fmt.Sprintf("{%s}", strings.Join(arr, ",")), nil
 }
+
+func (sm *SQLStateManager) GetRunStatus(runID string) (RunStatus, error) {
+	var status RunStatus
+
+	// Use a transaction with a short timeout to avoid blocking
+	tx, err := sm.db.Begin()
+	if err != nil {
+		return status, errors.Wrap(err, "failed to begin transaction")
+	}
+
+	// Set a short timeout for this query
+	_, err = tx.Exec("SET LOCAL lock_timeout = '500ms'")
+	if err != nil {
+		tx.Rollback()
+		return status, errors.Wrap(err, "failed to set lock timeout")
+	}
+
+	// Execute the query
+	err = tx.QueryRow(GetRunStatusSQL, runID).Scan(
+		&status.RunID,
+		&status.DefinitionID,
+		&status.Alias,
+		&status.ClusterName,
+		&status.Status,
+		&status.QueuedAt,
+		&status.StartedAt,
+		&status.FinishedAt,
+		&status.ExitCode,
+		&status.ExitReason,
+		&status.Engine,
+	)
+
+	if err != nil {
+		tx.Rollback()
+
+		if err == sql.ErrNoRows {
+			return status, exceptions.MissingResource{
+				ErrorString: fmt.Sprintf("Run with id %s not found", runID)}
+		}
+
+		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == "55P03" {
+			return status, exceptions.ConflictingResource{
+				ErrorString: fmt.Sprintf("Run with id %s is currently locked, please retry", runID)}
+		}
+
+		return status, errors.Wrapf(err, "issue getting run status with id [%s]", runID)
+	}
+
+	// Commit the transaction
+	err = tx.Commit()
+	if err != nil {
+		return status, errors.Wrap(err, "failed to commit transaction")
+	}
+
+	return status, nil
+}

--- a/state/pg_state_manager.go
+++ b/state/pg_state_manager.go
@@ -334,7 +334,7 @@ func (sm *SQLStateManager) ListDefinitions(
 func (sm *SQLStateManager) GetDefinition(definitionID string) (Definition, error) {
 	var err error
 	var definition Definition
-	err = sm.db.Get(&definition, GetDefinitionSQL, definitionID)
+	err = sm.readonlyDB.Get(&definition, GetDefinitionSQL, definitionID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return definition, exceptions.MissingResource{
@@ -350,7 +350,7 @@ func (sm *SQLStateManager) GetDefinition(definitionID string) (Definition, error
 func (sm *SQLStateManager) GetDefinitionByAlias(alias string) (Definition, error) {
 	var err error
 	var definition Definition
-	err = sm.db.Get(&definition, GetDefinitionByAliasSQL, alias)
+	err = sm.readonlyDB.Get(&definition, GetDefinitionByAliasSQL, alias)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return definition, exceptions.MissingResource{
@@ -673,7 +673,7 @@ func (sm *SQLStateManager) GetRunByEMRJobId(emrJobId string) (Run, error) {
 func (sm *SQLStateManager) GetResources(runID string) (Run, error) {
 	var err error
 	var r Run
-	err = sm.db.Get(&r, GetRunSQL, runID)
+	err = sm.readonlyDB.Get(&r, GetRunSQL, runID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return r, exceptions.MissingResource{

--- a/testutils/mocks.go
+++ b/testutils/mocks.go
@@ -563,3 +563,30 @@ func (iatt *ImplementsAllTheThings) CreateTemplate(t state.Template) error {
 	iatt.Templates[t.TemplateID] = t
 	return nil
 }
+
+func (iatt *ImplementsAllTheThings) GetRunStatus(runID string) (state.RunStatus, error) {
+	iatt.Calls = append(iatt.Calls, "GetRunStatus")
+	var err error
+
+	r, ok := iatt.Runs[runID]
+	if !ok {
+		err = fmt.Errorf("No run %s", runID)
+		return state.RunStatus{}, err
+	}
+
+	status := state.RunStatus{
+		RunID:        r.RunID,
+		Status:       r.Status,
+		DefinitionID: r.DefinitionID,
+		ClusterName:  r.ClusterName,
+		QueuedAt:     r.QueuedAt,
+		StartedAt:    r.StartedAt,
+		FinishedAt:   r.FinishedAt,
+		ExitCode:     r.ExitCode,
+		ExitReason:   r.ExitReason,
+		Engine:       r.Engine,
+		Alias:        r.Alias,
+	}
+
+	return status, err
+}


### PR DESCRIPTION
## PROBLEM
The current GetRun endpoint is querying much more data then we need and this leads to issues with timeouts getting hit

## SOLUTION
Add a lightweight runStatus endpoint that will allow operators and airflow to get the details it needs.