### PR TITLE
events_worker: no-op k8s event handling, stop tracking events altogether

### DIFF
--- a/worker/events_worker.go
+++ b/worker/events_worker.go
@@ -100,14 +100,12 @@ func (ew *eventsWorker) Run(ctx context.Context) error {
 }
 
 func (ew *eventsWorker) runOnceEMR(ctx context.Context) {
-	ctx, span := utils.TraceJob(ctx, "events_worker.run_once_emr", "events_worker")
-	defer span.Finish()
 	emrEvent, err := ew.qm.ReceiveEMREvent(ew.emrJobStatusQueue)
 	if err != nil {
 		_ = ew.log.Log("message", "Error receiving EMR Events", "error", fmt.Sprintf("%+v", err))
 		return
 	}
-	ew.processEventEMR(ctx, emrEvent)
+	_ = emrEvent.Done()
 }
 
 func (ew *eventsWorker) processEventEMR(ctx context.Context, emrEvent state.EmrEvent) {
@@ -182,14 +180,12 @@ func (ew *eventsWorker) processEventEMR(ctx context.Context, emrEvent state.EmrE
 	}
 }
 func (ew *eventsWorker) runOnce(ctx context.Context) {
-	ctx, span := utils.TraceJob(ctx, "events_worker.run_once_eks", "events_worker")
-	defer span.Finish()
 	kubernetesEvent, err := ew.qm.ReceiveKubernetesEvent(ew.queue)
 	if err != nil {
 		_ = ew.log.Log("message", "Error receiving Kubernetes Events", "error", fmt.Sprintf("%+v", err))
 		return
 	}
-	ew.processEvent(ctx, kubernetesEvent)
+	_ = kubernetesEvent.Done()
 }
 
 func (ew *eventsWorker) processEMRPodEvents(ctx context.Context, kubernetesEvent state.KubernetesEvent) {


### PR DESCRIPTION
https://stitchfix.atlassian.net/browse/DP-3734

## PROBLEM

We don't want to update the pod_events column anymore, as pod events can be viewed in datadog. The column previously grew unbounded, it's duplicative, and it's [no longer used for the UI](https://github.com/stitchfix/flotilla-ui/pull/62).

## SOLUTION

No-op event handling for both eks and emr.

## TODO

- Remove the sqs queues and eliminate their sources (sns, eventbridge, etc.)
- Remove the event worker completely