### PR TITLE
fix de-duping

### DIFF
--- a/worker/events_worker.go
+++ b/worker/events_worker.go
@@ -296,7 +296,10 @@ func (ew *eventsWorker) processEMRPodEvents(ctx context.Context, kubernetesEvent
 						}
 						if !found {
 							events = append(*run.PodEvents, event)
+						} else {
+							events = *run.PodEvents
 						}
+
 					} else {
 						events = state.PodEvents{event}
 					}


### PR DESCRIPTION
## PROBLEM

#557 had a bug in the de-duping code for recording EMR pod events.

## SOLUTION

Fix it.