### PR TITLE
Read client creds as env variables from secret key refs

### DIFF
--- a/execution/engine/emr_engine.go
+++ b/execution/engine/emr_engine.go
@@ -370,7 +370,7 @@ func (emr *EMRExecutionEngine) driverPodTemplate(ctx context.Context, executable
 		Containers: []v1.Container{
 			{
 				Name:         "spark-kubernetes-driver",
-				Env:          emr.envOverrides(executable, run),
+				Env:          append(emr.envOverrides(executable, run), emr.lakekeeperSecretEnvVars()...),
 				VolumeMounts: volumeMounts,
 				WorkingDir:   workingDir,
 			},
@@ -959,6 +959,65 @@ func (emr *EMRExecutionEngine) FetchUpdateStatus(ctx context.Context, run state.
 	utils.TagJobRun(span, run)
 	return run, nil
 }
+func (emr *EMRExecutionEngine) lakekeeperSecretEnvVars() []v1.EnvVar {
+	return []v1.EnvVar{
+		{
+			Name: "OAUTH2_CLIENT_ID",
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{Name: "client-credentials"},
+					Key:                  "client_id",
+				},
+			},
+		},
+		{
+			Name: "OAUTH2_CLIENT_SECRET",
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{Name: "client-credentials"},
+					Key:                  "client_secret",
+				},
+			},
+		},
+		{
+			Name: "OAUTH2_SERVER_URI",
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{Name: "client-credentials"},
+					Key:                  "token_url",
+				},
+			},
+		},
+		{
+			Name: "OAUTH2_SCOPE",
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{Name: "client-credentials"},
+					Key:                  "scope",
+				},
+			},
+		},
+		{
+			Name: "CATALOG_URI",
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{Name: "client-credentials"},
+					Key:                  "uri",
+				},
+			},
+		},
+		{
+			Name: "WAREHOUSE",
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{Name: "client-credentials"},
+					Key:                  "warehouse",
+				},
+			},
+		},
+	}
+}
+
 func (emr *EMRExecutionEngine) envOverrides(executable state.Executable, run state.Run) []v1.EnvVar {
 	pairs := make(map[string]string)
 	resources := executable.GetExecutableResources()

--- a/execution/engine/emr_engine.go
+++ b/execution/engine/emr_engine.go
@@ -972,6 +972,7 @@ func (emr *EMRExecutionEngine) lakekeeperSecretEnvVars() []v1.EnvVar {
 				SecretKeyRef: &v1.SecretKeySelector{
 					LocalObjectReference: v1.LocalObjectReference{Name: emr.lakekeeperSecretName},
 					Key:                  "client_id",
+					Optional:             aws.Bool(true),
 				},
 			},
 		},
@@ -981,6 +982,7 @@ func (emr *EMRExecutionEngine) lakekeeperSecretEnvVars() []v1.EnvVar {
 				SecretKeyRef: &v1.SecretKeySelector{
 					LocalObjectReference: v1.LocalObjectReference{Name: emr.lakekeeperSecretName},
 					Key:                  "client_secret",
+					Optional:             aws.Bool(true),
 				},
 			},
 		},
@@ -990,6 +992,7 @@ func (emr *EMRExecutionEngine) lakekeeperSecretEnvVars() []v1.EnvVar {
 				SecretKeyRef: &v1.SecretKeySelector{
 					LocalObjectReference: v1.LocalObjectReference{Name: emr.lakekeeperSecretName},
 					Key:                  "token_url",
+					Optional:             aws.Bool(true),
 				},
 			},
 		},
@@ -999,6 +1002,7 @@ func (emr *EMRExecutionEngine) lakekeeperSecretEnvVars() []v1.EnvVar {
 				SecretKeyRef: &v1.SecretKeySelector{
 					LocalObjectReference: v1.LocalObjectReference{Name: emr.lakekeeperSecretName},
 					Key:                  "scope",
+					Optional:             aws.Bool(true),
 				},
 			},
 		},
@@ -1008,6 +1012,7 @@ func (emr *EMRExecutionEngine) lakekeeperSecretEnvVars() []v1.EnvVar {
 				SecretKeyRef: &v1.SecretKeySelector{
 					LocalObjectReference: v1.LocalObjectReference{Name: emr.lakekeeperSecretName},
 					Key:                  "uri",
+					Optional:             aws.Bool(true),
 				},
 			},
 		},
@@ -1017,6 +1022,7 @@ func (emr *EMRExecutionEngine) lakekeeperSecretEnvVars() []v1.EnvVar {
 				SecretKeyRef: &v1.SecretKeySelector{
 					LocalObjectReference: v1.LocalObjectReference{Name: emr.lakekeeperSecretName},
 					Key:                  "warehouse",
+					Optional:             aws.Bool(true),
 				},
 			},
 		},

--- a/execution/engine/emr_engine.go
+++ b/execution/engine/emr_engine.go
@@ -58,6 +58,7 @@ type EMRExecutionEngine struct {
 	clusterManager      *DynamicClusterManager
 	stateManager        state.Manager
 	redisClient         *redis.Client
+	lakekeeperSecretName string
 }
 
 // Initialize configures the EMRExecutionEngine and initializes internal clients
@@ -78,6 +79,7 @@ func (emr *EMRExecutionEngine) Initialize(conf config.Config) error {
 	emr.emrJobSA = conf.GetString("emr_default_service_account")
 	emr.schedulerName = conf.GetString("eks_scheduler_name")
 	emr.driverInstanceType = conf.GetString("emr_driver_instance_type")
+	emr.lakekeeperSecretName = conf.GetString("emr_lakekeeper_secret_name")
 	awsConfig := &aws.Config{Region: aws.String(emr.awsRegion)}
 	sess := session.Must(session.NewSessionWithOptions(session.Options{Config: *awsConfig}))
 	sess = awstrace.WrapSession(sess)
@@ -960,12 +962,15 @@ func (emr *EMRExecutionEngine) FetchUpdateStatus(ctx context.Context, run state.
 	return run, nil
 }
 func (emr *EMRExecutionEngine) lakekeeperSecretEnvVars() []v1.EnvVar {
+	if emr.lakekeeperSecretName == "" {
+		return nil
+	}
 	return []v1.EnvVar{
 		{
 			Name: "OAUTH2_CLIENT_ID",
 			ValueFrom: &v1.EnvVarSource{
 				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{Name: "client-credentials"},
+					LocalObjectReference: v1.LocalObjectReference{Name: emr.lakekeeperSecretName},
 					Key:                  "client_id",
 				},
 			},
@@ -974,7 +979,7 @@ func (emr *EMRExecutionEngine) lakekeeperSecretEnvVars() []v1.EnvVar {
 			Name: "OAUTH2_CLIENT_SECRET",
 			ValueFrom: &v1.EnvVarSource{
 				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{Name: "client-credentials"},
+					LocalObjectReference: v1.LocalObjectReference{Name: emr.lakekeeperSecretName},
 					Key:                  "client_secret",
 				},
 			},
@@ -983,7 +988,7 @@ func (emr *EMRExecutionEngine) lakekeeperSecretEnvVars() []v1.EnvVar {
 			Name: "OAUTH2_SERVER_URI",
 			ValueFrom: &v1.EnvVarSource{
 				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{Name: "client-credentials"},
+					LocalObjectReference: v1.LocalObjectReference{Name: emr.lakekeeperSecretName},
 					Key:                  "token_url",
 				},
 			},
@@ -992,7 +997,7 @@ func (emr *EMRExecutionEngine) lakekeeperSecretEnvVars() []v1.EnvVar {
 			Name: "OAUTH2_SCOPE",
 			ValueFrom: &v1.EnvVarSource{
 				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{Name: "client-credentials"},
+					LocalObjectReference: v1.LocalObjectReference{Name: emr.lakekeeperSecretName},
 					Key:                  "scope",
 				},
 			},
@@ -1001,7 +1006,7 @@ func (emr *EMRExecutionEngine) lakekeeperSecretEnvVars() []v1.EnvVar {
 			Name: "CATALOG_URI",
 			ValueFrom: &v1.EnvVarSource{
 				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{Name: "client-credentials"},
+					LocalObjectReference: v1.LocalObjectReference{Name: emr.lakekeeperSecretName},
 					Key:                  "uri",
 				},
 			},
@@ -1010,7 +1015,7 @@ func (emr *EMRExecutionEngine) lakekeeperSecretEnvVars() []v1.EnvVar {
 			Name: "WAREHOUSE",
 			ValueFrom: &v1.EnvVarSource{
 				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{Name: "client-credentials"},
+					LocalObjectReference: v1.LocalObjectReference{Name: emr.lakekeeperSecretName},
 					Key:                  "warehouse",
 				},
 			},


### PR DESCRIPTION
## PROBLEM
Lakekeeper production is deployed with authentication enabled. Spark jobs running on flotilla-prod need to authenticate to Lakekeeper via the OAuth2 client credentials flow in order to use the Iceberg REST catalog.

## SOLUTION

Added a new lakekeeperSecretEnvVars() helper to EMRExecutionEngine that injects 6 environment variables into the Spark driver pod from a Kubernetes secret, enabling the OAuth2 client credentials 

JIRA link: https://stitchfix.atlassian.net/browse/DPL-345