### PR TITLE
Drivers are falling back to defaults 

### DIFF
--- a/execution/engine/emr_engine.go
+++ b/execution/engine/emr_engine.go
@@ -558,7 +558,11 @@ func (emr *EMRExecutionEngine) constructTolerations(executable state.Executable,
 			if run.Memory != nil && *run.Memory != 0 {
 				mem = *run.Memory
 			}
-			if !driver {
+			if driver {
+				if drvMem := driverMemoryMiB(run); drvMem > mem {
+					mem = drvMem
+				}
+			} else {
 				if execMem := executorMemoryMiB(run); execMem > mem {
 					mem = execMem
 				}
@@ -637,7 +641,11 @@ func (emr *EMRExecutionEngine) constructAffinity(ctx context.Context, executable
 			if run.Memory != nil && *run.Memory != 0 {
 				mem = *run.Memory
 			}
-			if !driver {
+			if driver {
+				if drvMem := driverMemoryMiB(run); drvMem > mem {
+					mem = drvMem
+				}
+			} else {
 				if execMem := executorMemoryMiB(run); execMem > mem {
 					mem = execMem
 				}
@@ -710,6 +718,18 @@ func (emr *EMRExecutionEngine) buildMetricTags(run state.Run) []string {
 		tags = append(tags, fmt.Sprintf("cluster:%s", run.ClusterName))
 	}
 	return tags
+}
+
+func driverMemoryMiB(run state.Run) int64 {
+	if run.SparkExtension == nil || run.SparkExtension.SparkSubmitJobDriver == nil {
+		return 0
+	}
+	for _, k := range run.SparkExtension.SparkSubmitJobDriver.SparkSubmitConf {
+		if k.Name != nil && *k.Name == "spark.driver.memory" && k.Value != nil {
+			return parseSparkMemoryMiB(*k.Value)
+		}
+	}
+	return 0
 }
 
 func executorMemoryMiB(run state.Run) int64 {

--- a/execution/engine/spark_memory_test.go
+++ b/execution/engine/spark_memory_test.go
@@ -1,0 +1,139 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stitchfix/flotilla-os/state"
+)
+
+func TestDriverMemoryMiB(t *testing.T) {
+	tests := []struct {
+		name     string
+		run      state.Run
+		expected int64
+	}{
+		{
+			name:     "nil spark extension",
+			run:      state.Run{},
+			expected: 0,
+		},
+		{
+			name: "no spark.driver.memory in conf",
+			run: state.Run{
+				SparkExtension: &state.SparkExtension{
+					SparkSubmitJobDriver: &state.SparkSubmitJobDriver{
+						SparkSubmitConf: []state.Conf{
+							{Name: aws.String("spark.executor.memory"), Value: aws.String("4g")},
+						},
+					},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name: "spark.driver.memory 40g",
+			run: state.Run{
+				SparkExtension: &state.SparkExtension{
+					SparkSubmitJobDriver: &state.SparkSubmitJobDriver{
+						SparkSubmitConf: []state.Conf{
+							{Name: aws.String("spark.driver.memory"), Value: aws.String("40g")},
+						},
+					},
+				},
+			},
+			expected: 40 * 1024,
+		},
+		{
+			name: "spark.driver.memory 512m",
+			run: state.Run{
+				SparkExtension: &state.SparkExtension{
+					SparkSubmitJobDriver: &state.SparkSubmitJobDriver{
+						SparkSubmitConf: []state.Conf{
+							{Name: aws.String("spark.driver.memory"), Value: aws.String("512m")},
+						},
+					},
+				},
+			},
+			expected: 512,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := driverMemoryMiB(tt.run)
+			if got != tt.expected {
+				t.Errorf("driverMemoryMiB() = %d, want %d", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExecutorMemoryMiB(t *testing.T) {
+	tests := []struct {
+		name     string
+		run      state.Run
+		expected int64
+	}{
+		{
+			name:     "nil spark extension",
+			run:      state.Run{},
+			expected: 0,
+		},
+		{
+			name: "ExecutorMemory field set",
+			run: state.Run{
+				SparkExtension: &state.SparkExtension{
+					SparkSubmitJobDriver: &state.SparkSubmitJobDriver{
+						ExecutorMemory: aws.Int64(8192),
+					},
+				},
+			},
+			expected: 8192,
+		},
+		{
+			name: "spark.executor.memory in conf",
+			run: state.Run{
+				SparkExtension: &state.SparkExtension{
+					SparkSubmitJobDriver: &state.SparkSubmitJobDriver{
+						SparkSubmitConf: []state.Conf{
+							{Name: aws.String("spark.executor.memory"), Value: aws.String("16g")},
+						},
+					},
+				},
+			},
+			expected: 16 * 1024,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := executorMemoryMiB(tt.run)
+			if got != tt.expected {
+				t.Errorf("executorMemoryMiB() = %d, want %d", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseSparkMemoryMiB(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int64
+	}{
+		{"40g", 40 * 1024},
+		{"1t", 1024 * 1024},
+		{"512m", 512},
+		{"2048k", 2},
+		{"invalid", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseSparkMemoryMiB(tt.input)
+			if got != tt.expected {
+				t.Errorf("parseSparkMemoryMiB(%q) = %d, want %d", tt.input, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## PROBLEM
We need drivers to schedule on the correct nodes some of the large drivers were scheduling on the small node pool while they should be on the medium  this is due to a fallback in the code

## SOLUTION
Correct the logic on the fallback