### PR TITLE
Add shared-pool capability for static ETL NodePool routing

### DIFF
--- a/execution/adapter/eks_adapter.go
+++ b/execution/adapter/eks_adapter.go
@@ -216,14 +216,21 @@ func (a *eksAdapter) constructTolerations(executable state.Executable, run state
 
 	isWaitForData := run.Labels["kube_task_type"] == "wait_for_data"
 	if team, ok := run.Labels["team"]; ok && team != "" && !isGPU && !isWaitForData {
-		tolerations = append(tolerations, corev1.Toleration{
-			Key:      team,
-			Operator: "Equal",
-			Value:    "true",
-			Effect:   "NoSchedule",
-		})
+		if !capabilities.Has(state.CapSharedPool) {
+			tolerations = append(tolerations, corev1.Toleration{
+				Key:      team,
+				Operator: "Equal",
+				Value:    "true",
+				Effect:   "NoSchedule",
+			})
+		}
 
-		if capabilities.Has(state.CapPoolSizing) {
+		if capabilities.Has(state.CapSharedPool) {
+			cpu, mem := a.getResourceDefaults(run, executable)
+			size := state.PoolSize(cpu, mem)
+			routing := state.SharedPoolRouting(size)
+			tolerations = append(tolerations, routing.Tolerations...)
+		} else if capabilities.Has(state.CapPoolSizing) {
 			cpu, mem := a.getResourceDefaults(run, executable)
 			size := state.PoolSize(cpu, mem)
 			tolerations = append(tolerations, corev1.Toleration{
@@ -275,13 +282,25 @@ func (a *eksAdapter) constructAffinity(ctx context.Context, executable state.Exe
 	isGPU := (run.Gpu != nil && *run.Gpu > 0) || (executableResources.Gpu != nil && *executableResources.Gpu > 0)
 	isWaitForData := run.Labels["kube_task_type"] == "wait_for_data"
 	if team, ok := run.Labels["team"]; ok && team != "" && !isGPU && !isWaitForData {
-		requiredMatch = append(requiredMatch, corev1.NodeSelectorRequirement{
-			Key:      "team",
-			Operator: corev1.NodeSelectorOpIn,
-			Values:   []string{team},
-		})
+		if !capabilities.Has(state.CapSharedPool) {
+			requiredMatch = append(requiredMatch, corev1.NodeSelectorRequirement{
+				Key:      "team",
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{team},
+			})
+		}
 
-		if capabilities.Has(state.CapPoolSizing) {
+		if capabilities.Has(state.CapSharedPool) {
+			cpu, mem := a.getResourceDefaults(run, executable)
+			size := state.PoolSize(cpu, mem)
+			routing := state.SharedPoolRouting(size)
+			if routing.RequiredAffinity != nil {
+				requiredMatch = append(requiredMatch, *routing.RequiredAffinity)
+			}
+			if routing.PreferredAffinity != nil {
+				preferredMatches = append(preferredMatches, *routing.PreferredAffinity)
+			}
+		} else if capabilities.Has(state.CapPoolSizing) {
 			cpu, mem := a.getResourceDefaults(run, executable)
 			size := state.PoolSize(cpu, mem)
 			requiredMatch = append(requiredMatch, corev1.NodeSelectorRequirement{

--- a/execution/engine/emr_engine.go
+++ b/execution/engine/emr_engine.go
@@ -541,7 +541,34 @@ func (emr *EMRExecutionEngine) constructTolerations(executable state.Executable,
 		Effect:   "NoSchedule",
 	})
 
-	if team, ok := run.Labels["team"]; ok && team != "" {
+	if capabilities.Has(state.CapSharedPool) {
+		cpu := state.MinCPU
+		mem := state.MinMem
+		if run.Cpu != nil && *run.Cpu != 0 {
+			cpu = *run.Cpu
+		}
+		if run.Memory != nil && *run.Memory != 0 {
+			mem = *run.Memory
+		}
+		if driver {
+			if drvCPU := driverCPUMillis(run); drvCPU > cpu {
+				cpu = drvCPU
+			}
+			if drvMem := driverMemoryMiB(run); drvMem > mem {
+				mem = drvMem
+			}
+		} else {
+			if execCPU := executorCPUMillis(run); execCPU > cpu {
+				cpu = execCPU
+			}
+			if execMem := executorMemoryMiB(run); execMem > mem {
+				mem = execMem
+			}
+		}
+		size := state.PoolSize(cpu, mem)
+		routing := state.SharedPoolRouting(size)
+		tolerations = append(tolerations, routing.Tolerations...)
+	} else if team, ok := run.Labels["team"]; ok && team != "" {
 		tolerations = append(tolerations, v1.Toleration{
 			Key:      team,
 			Operator: "Equal",
@@ -592,6 +619,7 @@ func (emr *EMRExecutionEngine) constructAffinity(ctx context.Context, executable
 		ctx = context.Background()
 	}
 	var requiredMatch []v1.NodeSelectorRequirement
+	var preferredMatches []v1.PreferredSchedulingTerm
 	//todo move to config
 	nodeLifecycleKey := "karpenter.sh/capacity-type"
 	nodeArchKey := "kubernetes.io/arch"
@@ -631,7 +659,39 @@ func (emr *EMRExecutionEngine) constructAffinity(ctx context.Context, executable
 		Values:   arch,
 	})
 
-	if team, ok := run.Labels["team"]; ok && team != "" {
+	if capabilities.Has(state.CapSharedPool) {
+		cpu := state.MinCPU
+		mem := state.MinMem
+		if run.Cpu != nil && *run.Cpu != 0 {
+			cpu = *run.Cpu
+		}
+		if run.Memory != nil && *run.Memory != 0 {
+			mem = *run.Memory
+		}
+		if driver {
+			if drvCPU := driverCPUMillis(run); drvCPU > cpu {
+				cpu = drvCPU
+			}
+			if drvMem := driverMemoryMiB(run); drvMem > mem {
+				mem = drvMem
+			}
+		} else {
+			if execCPU := executorCPUMillis(run); execCPU > cpu {
+				cpu = execCPU
+			}
+			if execMem := executorMemoryMiB(run); execMem > mem {
+				mem = execMem
+			}
+		}
+		size := state.PoolSize(cpu, mem)
+		routing := state.SharedPoolRouting(size)
+		if routing.RequiredAffinity != nil {
+			requiredMatch = append(requiredMatch, *routing.RequiredAffinity)
+		}
+		if routing.PreferredAffinity != nil {
+			preferredMatches = append(preferredMatches, *routing.PreferredAffinity)
+		}
+	} else if team, ok := run.Labels["team"]; ok && team != "" {
 		requiredMatch = append(requiredMatch, v1.NodeSelectorRequirement{
 			Key:      "team",
 			Operator: v1.NodeSelectorOpIn,
@@ -681,6 +741,17 @@ func (emr *EMRExecutionEngine) constructAffinity(ctx context.Context, executable
 		})
 	}
 
+	preferredMatches = append(preferredMatches, v1.PreferredSchedulingTerm{
+		Weight: 50,
+		Preference: v1.NodeSelectorTerm{
+			MatchExpressions: []v1.NodeSelectorRequirement{{
+				Key:      nodeLifecycleKey,
+				Operator: v1.NodeSelectorOpIn,
+				Values:   []string{nodePreference},
+			}},
+		},
+	})
+
 	affinity = &v1.Affinity{
 		NodeAffinity: &v1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
@@ -690,16 +761,7 @@ func (emr *EMRExecutionEngine) constructAffinity(ctx context.Context, executable
 					},
 				},
 			},
-			PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{{
-				Weight: 50,
-				Preference: v1.NodeSelectorTerm{
-					MatchExpressions: []v1.NodeSelectorRequirement{{
-						Key:      nodeLifecycleKey,
-						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{nodePreference},
-					}},
-				},
-			}},
+			PreferredDuringSchedulingIgnoredDuringExecution: preferredMatches,
 		},
 		PodAffinity: &v1.PodAffinity{
 			PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{

--- a/state/models.go
+++ b/state/models.go
@@ -1255,6 +1255,7 @@ type Capability string
 type Capabilities []string
 
 const CapPoolSizing = "pool-sizing"
+const CapSharedPool = "shared-pool"
 
 func (c Capabilities) Has(cap string) bool {
 	for _, v := range c {

--- a/state/pool_routing.go
+++ b/state/pool_routing.go
@@ -1,0 +1,30 @@
+package state
+
+import corev1 "k8s.io/api/core/v1"
+
+type PoolRouting struct {
+	RequiredAffinity  *corev1.NodeSelectorRequirement
+	PreferredAffinity *corev1.PreferredSchedulingTerm
+	Tolerations       []corev1.Toleration
+}
+
+func SharedPoolRouting(size string) PoolRouting {
+	pool := "standard"
+	switch size {
+	case "l":
+		pool = "large"
+	case "xl":
+		pool = "xl"
+	}
+
+	return PoolRouting{
+		RequiredAffinity: &corev1.NodeSelectorRequirement{
+			Key:      "flotilla-pool",
+			Operator: corev1.NodeSelectorOpIn,
+			Values:   []string{pool},
+		},
+		Tolerations: []corev1.Toleration{
+			{Key: "flotilla-pool", Operator: "Equal", Value: pool, Effect: "NoSchedule"},
+		},
+	}
+}

--- a/state/pool_routing_test.go
+++ b/state/pool_routing_test.go
@@ -1,0 +1,94 @@
+package state
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestSharedPoolRouting_Small(t *testing.T) {
+	r := SharedPoolRouting("s")
+	assertRequiredPool(t, r, "standard")
+	assertTolerationValues(t, r.Tolerations, []string{"standard"})
+}
+
+func TestSharedPoolRouting_Medium(t *testing.T) {
+	r := SharedPoolRouting("m")
+	assertRequiredPool(t, r, "standard")
+	assertTolerationValues(t, r.Tolerations, []string{"standard"})
+}
+
+func TestSharedPoolRouting_Large(t *testing.T) {
+	r := SharedPoolRouting("l")
+	assertRequiredPool(t, r, "large")
+	assertTolerationValues(t, r.Tolerations, []string{"large"})
+}
+
+func TestSharedPoolRouting_XL(t *testing.T) {
+	r := SharedPoolRouting("xl")
+	assertRequiredPool(t, r, "xl")
+	assertTolerationValues(t, r.Tolerations, []string{"xl"})
+}
+
+func TestSharedPoolRouting_Unknown(t *testing.T) {
+	r := SharedPoolRouting("unknown")
+	assertRequiredPool(t, r, "standard")
+}
+
+func TestSharedPoolRouting_SmallAndMediumAreIdentical(t *testing.T) {
+	s := SharedPoolRouting("s")
+	m := SharedPoolRouting("m")
+	if s.RequiredAffinity.Values[0] != m.RequiredAffinity.Values[0] {
+		t.Errorf("small and medium should route to same pool")
+	}
+}
+
+func TestSharedPoolRouting_NoCrossPoolTolerations(t *testing.T) {
+	for _, size := range []string{"s", "m", "l", "xl"} {
+		r := SharedPoolRouting(size)
+		if len(r.Tolerations) != 1 {
+			t.Errorf("size %q: expected exactly 1 toleration, got %d", size, len(r.Tolerations))
+		}
+	}
+}
+
+func TestSharedPoolRouting_NoPreferredAffinity(t *testing.T) {
+	for _, size := range []string{"s", "m", "l", "xl"} {
+		r := SharedPoolRouting(size)
+		if r.PreferredAffinity != nil {
+			t.Errorf("size %q: should not have preferred affinity", size)
+		}
+	}
+}
+
+func assertRequiredPool(t *testing.T, r PoolRouting, expected string) {
+	t.Helper()
+	if r.RequiredAffinity == nil {
+		t.Fatal("expected required affinity")
+	}
+	if r.RequiredAffinity.Key != "flotilla-pool" {
+		t.Errorf("required key should be flotilla-pool, got %s", r.RequiredAffinity.Key)
+	}
+	if r.RequiredAffinity.Values[0] != expected {
+		t.Errorf("required value should be %s, got %v", expected, r.RequiredAffinity.Values)
+	}
+}
+
+func assertTolerationValues(t *testing.T, tolerations []corev1.Toleration, expected []string) {
+	t.Helper()
+	if len(tolerations) != len(expected) {
+		t.Errorf("expected %d tolerations, got %d", len(expected), len(tolerations))
+		return
+	}
+	for i, tol := range tolerations {
+		if tol.Key != "flotilla-pool" {
+			t.Errorf("toleration[%d] key should be flotilla-pool, got %s", i, tol.Key)
+		}
+		if tol.Value != expected[i] {
+			t.Errorf("toleration[%d] value should be %s, got %s", i, expected[i], tol.Value)
+		}
+		if tol.Effect != "NoSchedule" {
+			t.Errorf("toleration[%d] effect should be NoSchedule, got %s", i, tol.Effect)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Introduces `shared-pool` cluster capability that routes pods to shared static NodePools using `flotilla-pool` label only
- Removes team as a scheduling dimension (node affinity + toleration) when shared-pool is active
- Collapses small and standard into a single standard pool for better bin-packing
- Preserves team label on pods for attribution/cost-allocation
- GPU and wait_for_data jobs unaffected
- Existing `pool-sizing` capability remains unchanged for backward compat

## Routing rules (when shared-pool enabled)
| Pool Size | Affinity | Tolerations |
|-----------|----------|-------------|
| small/medium | preferred=standard | standard |
| large | preferred=large | large |
| xl | required=xl | xl |
