### PR TITLE
Skip emr=true required affinity when shared-pool active 

### DIFF
--- a/execution/engine/emr_engine.go
+++ b/execution/engine/emr_engine.go
@@ -733,7 +733,7 @@ func (emr *EMRExecutionEngine) constructAffinity(ctx context.Context, executable
 
 	//todo remove conditional after migration
 	_, hasTeam := run.Labels["team"]
-	if newCluster && !hasTeam {
+	if newCluster && !hasTeam && !capabilities.Has(state.CapSharedPool) {
 		requiredMatch = append(requiredMatch, v1.NodeSelectorRequirement{
 			Key:      "emr",
 			Operator: v1.NodeSelectorOpIn,


### PR DESCRIPTION
EMR pods without a team label were getting both flotilla-pool=standard and emr=true as required node affinities. No NodePool satisfies both, causing pods to stay Pending. Skip the emr fallback affinity when shared-pool routing handles placement.

