### PR TITLE
Raise xl memory threshold to 234000 MiB

### DIFF
--- a/state/pool_size.go
+++ b/state/pool_size.go
@@ -2,7 +2,7 @@ package state
 
 func PoolSize(cpuMillis, memoryMiB int64) string {
 	switch {
-	case cpuMillis >= 30000 || memoryMiB >= 200000:
+	case cpuMillis >= 30000 || memoryMiB >= 234000:
 		return "xl"
 	case cpuMillis >= 14000 || memoryMiB >= 100000:
 		return "l"

--- a/state/pool_size_test.go
+++ b/state/pool_size_test.go
@@ -16,10 +16,10 @@ func TestPoolSize(t *testing.T) {
 		{"max medium cpu", 13999, 99999, "m"},
 		{"cpu triggers large", 14000, 512, "l"},
 		{"mem triggers large", 256, 100000, "l"},
-		{"max large cpu", 29999, 199999, "l"},
+		{"max large cpu", 29999, 233999, "l"},
 		{"cpu triggers xl", 30000, 512, "xl"},
-		{"mem triggers xl", 256, 200000, "xl"},
-		{"both large", 60000, 350000, "xl"},
+		{"mem triggers xl", 256, 234000, "xl"},
+		{"both xl", 60000, 350000, "xl"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Raises xl memory threshold from 200000 to 234000 MiB
- Jobs requesting < 250Gi memory can fit on r6a.8xlarge (233Gi allocatable) in the large pool
- CPU threshold stays at 30000m
- Fixes 200G/10cpu jobs incorrectly routing to xl when they fit on large pool nodes