### PR TITLE
Increase EMR logging container memory

### DIFF
--- a/execution/engine/emr_engine.go
+++ b/execution/engine/emr_engine.go
@@ -63,6 +63,12 @@ type EMRExecutionEngine struct {
 	lakekeeperSecretName string
 }
 
+const (
+	emrContainersDefaultsClassification = "emr-containers-defaults"
+	loggingRequestMemoryKey             = "logging.request.memory"
+	loggingRequestMemoryDefault         = "1Gi"
+)
+
 // Initialize configures the EMRExecutionEngine and initializes internal clients
 func (emr *EMRExecutionEngine) Initialize(conf config.Config) error {
 
@@ -253,6 +259,16 @@ func (emr *EMRExecutionEngine) generateApplicationConf(ctx context.Context, exec
 		{
 			Classification: aws.String("spark-hive-site"),
 			Properties:     hiveDefaults,
+		},
+		emrContainersDefaultsConf(),
+	}
+}
+
+func emrContainersDefaultsConf() *emrcontainers.Configuration {
+	return &emrcontainers.Configuration{
+		Classification: aws.String(emrContainersDefaultsClassification),
+		Properties: map[string]*string{
+			loggingRequestMemoryKey: aws.String(loggingRequestMemoryDefault),
 		},
 	}
 }

--- a/execution/engine/emr_engine_test.go
+++ b/execution/engine/emr_engine_test.go
@@ -1,0 +1,19 @@
+package engine
+
+import "testing"
+
+func TestEMRContainersDefaultsConfSetsLoggingMemory(t *testing.T) {
+	conf := emrContainersDefaultsConf()
+
+	if got := *conf.Classification; got != emrContainersDefaultsClassification {
+		t.Fatalf("classification = %q, want %q", got, emrContainersDefaultsClassification)
+	}
+
+	got, ok := conf.Properties[loggingRequestMemoryKey]
+	if !ok {
+		t.Fatalf("missing %q property", loggingRequestMemoryKey)
+	}
+	if *got != loggingRequestMemoryDefault {
+		t.Fatalf("%s = %q, want %q", loggingRequestMemoryKey, *got, loggingRequestMemoryDefault)
+	}
+}


### PR DESCRIPTION
## PROBLEM

OOM on sidecar for spark jobs see https://stitchfix.slack.com/archives/CLZM9V1AR/p1783455969821649

## SOLUTION

Add a default of 1gi, recommendation coming from AWS https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/emr-eks-job-submitter-container-defaults.html