### PR TITLE
[DPL-251] Inject DATAHUB_TOKEN into flotilla driver and task pods

### DIFF
--- a/execution/adapter/eks_adapter.go
+++ b/execution/adapter/eks_adapter.go
@@ -807,6 +807,17 @@ func (a *eksAdapter) lakekeeperSecretEnvVars() []corev1.EnvVar {
 				},
 			},
 		},
+		{
+			// DataHub PAT, used by sfs3 to read PD metadata for fumigation.
+			Name: "DATAHUB_TOKEN",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: a.lakekeeperSecretName},
+					Key:                  "DATAHUB_TOKEN",
+					Optional:             aws.Bool(true),
+				},
+			},
+		},
 	}
 }
 

--- a/execution/adapter/eks_adapter_test.go
+++ b/execution/adapter/eks_adapter_test.go
@@ -651,3 +651,64 @@ func TestEmitARAMetrics_NilLogger(t *testing.T) {
 func int64Ptr(i int64) *int64 {
 	return &i
 }
+
+// env var name -> key within the client-credentials secret. DATAHUB_TOKEN is the
+// one key that is upper-case.
+var wantLakekeeperSecretKeys = map[string]string{
+	"OAUTH2_CLIENT_ID":     "client_id",
+	"OAUTH2_CLIENT_SECRET": "client_secret",
+	"OAUTH2_SERVER_URI":    "token_url",
+	"OAUTH2_SCOPE":         "scope",
+	"CATALOG_URI":          "uri",
+	"WAREHOUSE":            "warehouse",
+	"DATAHUB_TOKEN":        "DATAHUB_TOKEN",
+}
+
+func TestLakekeeperSecretEnvVars(t *testing.T) {
+	const secretName = "client-credentials"
+	adapter := &eksAdapter{lakekeeperSecretName: secretName}
+
+	got := adapter.lakekeeperSecretEnvVars()
+	if len(got) != len(wantLakekeeperSecretKeys) {
+		t.Fatalf("env var count = %d, want %d", len(got), len(wantLakekeeperSecretKeys))
+	}
+
+	seen := make(map[string]bool, len(got))
+	for _, ev := range got {
+		wantKey, ok := wantLakekeeperSecretKeys[ev.Name]
+		if !ok {
+			t.Errorf("unexpected env var %q", ev.Name)
+			continue
+		}
+		seen[ev.Name] = true
+
+		if ev.ValueFrom == nil || ev.ValueFrom.SecretKeyRef == nil {
+			t.Errorf("%s: want a SecretKeyRef, got none", ev.Name)
+			continue
+		}
+		ref := ev.ValueFrom.SecretKeyRef
+		if ref.Name != secretName {
+			t.Errorf("%s: secret = %q, want %q", ev.Name, ref.Name, secretName)
+		}
+		if ref.Key != wantKey {
+			t.Errorf("%s: key = %q, want %q", ev.Name, ref.Key, wantKey)
+		}
+		// Optional keeps pods schedulable on clusters whose secret lacks the key.
+		if ref.Optional == nil || !*ref.Optional {
+			t.Errorf("%s: Optional not set to true", ev.Name)
+		}
+	}
+
+	for name := range wantLakekeeperSecretKeys {
+		if !seen[name] {
+			t.Errorf("missing env var %q", name)
+		}
+	}
+}
+
+func TestLakekeeperSecretEnvVarsNotConfigured(t *testing.T) {
+	adapter := &eksAdapter{}
+	if got := adapter.lakekeeperSecretEnvVars(); got != nil {
+		t.Fatalf("env var count = %d, want none when no secret is configured", len(got))
+	}
+}

--- a/execution/engine/emr_engine.go
+++ b/execution/engine/emr_engine.go
@@ -1297,6 +1297,17 @@ func (emr *EMRExecutionEngine) lakekeeperSecretEnvVars() []v1.EnvVar {
 				},
 			},
 		},
+		{
+			// DataHub PAT, used by sfs3 to read PD metadata for fumigation.
+			Name: "DATAHUB_TOKEN",
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{Name: emr.lakekeeperSecretName},
+					Key:                  "DATAHUB_TOKEN",
+					Optional:             aws.Bool(true),
+				},
+			},
+		},
 	}
 }
 

--- a/execution/engine/emr_engine_test.go
+++ b/execution/engine/emr_engine_test.go
@@ -17,3 +17,64 @@ func TestEMRContainersDefaultsConfSetsLoggingMemory(t *testing.T) {
 		t.Fatalf("%s = %q, want %q", loggingRequestMemoryKey, *got, loggingRequestMemoryDefault)
 	}
 }
+
+// env var name -> key within the client-credentials secret. DATAHUB_TOKEN is the
+// one key that is upper-case.
+var wantLakekeeperSecretKeys = map[string]string{
+	"OAUTH2_CLIENT_ID":     "client_id",
+	"OAUTH2_CLIENT_SECRET": "client_secret",
+	"OAUTH2_SERVER_URI":    "token_url",
+	"OAUTH2_SCOPE":         "scope",
+	"CATALOG_URI":          "uri",
+	"WAREHOUSE":            "warehouse",
+	"DATAHUB_TOKEN":        "DATAHUB_TOKEN",
+}
+
+func TestLakekeeperSecretEnvVars(t *testing.T) {
+	const secretName = "client-credentials"
+	emr := &EMRExecutionEngine{lakekeeperSecretName: secretName}
+
+	got := emr.lakekeeperSecretEnvVars()
+	if len(got) != len(wantLakekeeperSecretKeys) {
+		t.Fatalf("env var count = %d, want %d", len(got), len(wantLakekeeperSecretKeys))
+	}
+
+	seen := make(map[string]bool, len(got))
+	for _, ev := range got {
+		wantKey, ok := wantLakekeeperSecretKeys[ev.Name]
+		if !ok {
+			t.Errorf("unexpected env var %q", ev.Name)
+			continue
+		}
+		seen[ev.Name] = true
+
+		if ev.ValueFrom == nil || ev.ValueFrom.SecretKeyRef == nil {
+			t.Errorf("%s: want a SecretKeyRef, got none", ev.Name)
+			continue
+		}
+		ref := ev.ValueFrom.SecretKeyRef
+		if ref.Name != secretName {
+			t.Errorf("%s: secret = %q, want %q", ev.Name, ref.Name, secretName)
+		}
+		if ref.Key != wantKey {
+			t.Errorf("%s: key = %q, want %q", ev.Name, ref.Key, wantKey)
+		}
+		// Optional keeps pods schedulable on clusters whose secret lacks the key.
+		if ref.Optional == nil || !*ref.Optional {
+			t.Errorf("%s: Optional not set to true", ev.Name)
+		}
+	}
+
+	for name := range wantLakekeeperSecretKeys {
+		if !seen[name] {
+			t.Errorf("missing env var %q", name)
+		}
+	}
+}
+
+func TestLakekeeperSecretEnvVarsNotConfigured(t *testing.T) {
+	emr := &EMRExecutionEngine{}
+	if got := emr.lakekeeperSecretEnvVars(); got != nil {
+		t.Fatalf("env var count = %d, want none when no secret is configured", len(got))
+	}
+}


### PR DESCRIPTION
## Problem

sfs3's fumigation path looks up PD metadata in DataHub. `DataHubClient` resolves its PAT from the `DATAHUB_TOKEN` env var, driver-side. The token is already in the `client-credentials` secret, but `lakekeeperSecretEnvVars()` hardcodes only the six lakekeeper keys, so it is never mapped onto the pod.

## Solution

Add `DATAHUB_TOKEN` as a seventh `SecretKeyRef` in `lakekeeperSecretEnvVars()`, sourced from the same `lakekeeperSecretName` secret. Updated in both copies: the EMR `spark-kubernetes-driver` and the EKS task pod.